### PR TITLE
refactor: replace instanceof with null-checks and polymorphism

### DIFF
--- a/backend/app/Domain/Matching/Actions/MatchBranch.php
+++ b/backend/app/Domain/Matching/Actions/MatchBranch.php
@@ -38,7 +38,7 @@ final readonly class MatchBranch
         /** @var Task|null $task */
         $task = Task::where('bitrix24_task_id', (int) $parsedTaskNumber)->first();
 
-        if ($task instanceof Task) {
+        if ($task !== null) {
             return [$task, ConfidenceLevel::Auto];
         }
 

--- a/backend/app/Domain/Narrative/Contracts/HasNarrativeSource.php
+++ b/backend/app/Domain/Narrative/Contracts/HasNarrativeSource.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Narrative\Contracts;
+
+use App\Domain\Narrative\Enums\NarrativeSource;
+
+interface HasNarrativeSource
+{
+    public function source(): NarrativeSource;
+}

--- a/backend/app/Domain/Narrative/Events/NarrativeEdited.php
+++ b/backend/app/Domain/Narrative/Events/NarrativeEdited.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Domain\Narrative\Events;
 
+use App\Domain\Narrative\Contracts\HasNarrativeSource;
+use App\Domain\Narrative\Enums\NarrativeSource;
 use App\Domain\Report\Models\ReportDay;
 use App\Domain\Report\Models\ReportTask;
 use Illuminate\Foundation\Events\Dispatchable;
 
-final readonly class NarrativeEdited
+final readonly class NarrativeEdited implements HasNarrativeSource
 {
     use Dispatchable;
 
@@ -16,5 +18,10 @@ final readonly class NarrativeEdited
         public ReportTask|ReportDay $narratable,
         public string $previousNarrative,
     ) {
+    }
+
+    public function source(): NarrativeSource
+    {
+        return NarrativeSource::ManualEdit;
     }
 }

--- a/backend/app/Domain/Narrative/Events/NarrativeRegenerated.php
+++ b/backend/app/Domain/Narrative/Events/NarrativeRegenerated.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Domain\Narrative\Events;
 
+use App\Domain\Narrative\Contracts\HasNarrativeSource;
+use App\Domain\Narrative\Enums\NarrativeSource;
 use App\Domain\Report\Models\ReportDay;
 use App\Domain\Report\Models\ReportTask;
 use Illuminate\Foundation\Events\Dispatchable;
 
-final readonly class NarrativeRegenerated
+final readonly class NarrativeRegenerated implements HasNarrativeSource
 {
     use Dispatchable;
 
@@ -16,5 +18,10 @@ final readonly class NarrativeRegenerated
         public ReportTask|ReportDay $narratable,
         public string $previousNarrative,
     ) {
+    }
+
+    public function source(): NarrativeSource
+    {
+        return NarrativeSource::LlmRegeneration;
     }
 }

--- a/backend/app/Domain/Narrative/Listeners/SaveNarrativeHistory.php
+++ b/backend/app/Domain/Narrative/Listeners/SaveNarrativeHistory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Domain\Narrative\Listeners;
 
-use App\Domain\Narrative\Enums\NarrativeSource;
 use App\Domain\Narrative\Events\NarrativeEdited;
 use App\Domain\Narrative\Events\NarrativeRegenerated;
 use App\Domain\Narrative\Models\NarrativeHistory;
@@ -18,14 +17,10 @@ final readonly class SaveNarrativeHistory
 
     public function handle(NarrativeEdited|NarrativeRegenerated $event): void
     {
-        $source = $event instanceof NarrativeEdited
-            ? NarrativeSource::ManualEdit
-            : NarrativeSource::LlmRegeneration;
-
         $event->narratable->narrativeHistory()->create([
             'previous_narrative' => $event->previousNarrative,
             'changed_at'         => now(),
-            'source'             => $source,
+            'source'             => $event->source(),
         ]);
 
         $this->pruneHistory($event->narratable);

--- a/backend/app/Jobs/RunSyncJob.php
+++ b/backend/app/Jobs/RunSyncJob.php
@@ -66,7 +66,7 @@ class RunSyncJob implements ShouldQueue
     {
         $syncJob = SyncJob::find($this->syncJobId);
 
-        if ($syncJob instanceof SyncJob && $syncJob->status === SyncStatus::InProgress) {
+        if ($syncJob !== null && $syncJob->status === SyncStatus::InProgress) {
             $syncJob->markFailed($exception->getMessage());
             $this->publishProgress(['status' => 'failed', 'error_message' => $exception->getMessage()]);
         }


### PR DESCRIPTION
Replace instanceof type-guards with null-checks in MatchBranch and RunSyncJob where they served as nullable guards after Eloquent queries. Extract HasNarrativeSource interface so narrative events carry their own source instead of the listener checking event type via instanceof.

Closes #12 