### PR TITLE
refactor: replace array shapes with DTOs for report export data

### DIFF
--- a/backend/app/Console/Commands/TestWordExport.php
+++ b/backend/app/Console/Commands/TestWordExport.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Domain\Report\DTOs\ReportExportData;
+use App\Domain\Report\DTOs\ReportExportDay;
+use App\Domain\Report\DTOs\ReportExportTask;
 use App\Infrastructure\Report\WordExporter;
 use Illuminate\Console\Command;
 
@@ -37,78 +40,76 @@ class TestWordExport extends Command
         return self::SUCCESS;
     }
 
-    /**
-     * @return array{developer_name: string, developer_position: string, date_from: string, date_to: string, days: array<int, array{date: string, narrative: string, tasks: array<int, array{number: int|string, title: string, project_name: string, narrative: string}>}>}
-     */
-    private function buildTestData(): array
+    private function buildTestData(): ReportExportData
     {
-        return [
-            'developer_name'     => 'Иванов Иван Иванович',
-            'developer_position' => 'Разработчик',
-            'date_from'          => '2024-01-01',
-            'date_to'            => '2024-01-03',
-            'days'               => [
-                [
-                    'date'      => '2024-01-01',
-                    'narrative' => 'В понедельник выполнена основная работа по реализации модуля авторизации и начата интеграция с внешним API.',
-                    'tasks'     => [
-                        [
-                            'number'       => 1,
-                            'title'        => 'Реализация модуля авторизации',
-                            'project_name' => 'ProjectX',
-                            'narrative'    => 'Реализована авторизация через OAuth2: добавлен endpoint для входа, обработана граничная ситуация с истечением токена. Код вынесен в отдельный сервис для улучшения поддерживаемости.',
-                        ],
-                        [
-                            'number'       => 2,
-                            'title'        => 'Интеграция с внешним API платёжного шлюза',
-                            'project_name' => 'ProjectX',
-                            'narrative'    => 'Начата интеграция с платёжным шлюзом: изучена документация API, реализован базовый HTTP-клиент, добавлена обработка ошибок сети.',
-                        ],
+        return new ReportExportData(
+            type: 'custom',
+            developerName: 'Иванов Иван Иванович',
+            developerPosition: 'Разработчик',
+            dateFrom: '2024-01-01',
+            dateTo: '2024-01-03',
+            days: [
+                new ReportExportDay(
+                    date: '2024-01-01',
+                    tasks: [
+                        new ReportExportTask(
+                            title: 'Реализация модуля авторизации',
+                            projectName: 'ProjectX',
+                            narrative: 'Реализована авторизация через OAuth2: добавлен endpoint для входа, обработана граничная ситуация с истечением токена. Код вынесен в отдельный сервис для улучшения поддерживаемости.',
+                            number: 1,
+                        ),
+                        new ReportExportTask(
+                            title: 'Интеграция с внешним API платёжного шлюза',
+                            projectName: 'ProjectX',
+                            narrative: 'Начата интеграция с платёжным шлюзом: изучена документация API, реализован базовый HTTP-клиент, добавлена обработка ошибок сети.',
+                            number: 2,
+                        ),
                     ],
-                ],
-                [
-                    'date'      => '2024-01-02',
-                    'narrative' => 'Исправлены критические ошибки в модуле импорта и выполнен рефакторинг сервисного слоя.',
-                    'tasks'     => [
-                        [
-                            'number'       => 3,
-                            'title'        => 'Исправление ошибки отображения таблицы цен',
-                            'project_name' => 'MS-11 CRM',
-                            'narrative'    => 'Исправлена ошибка отображения таблицы цен на мобильных устройствах. Добавлена адаптивная вёрстка для экранов шириной менее 768px.',
-                        ],
-                        [
-                            'number'       => 4,
-                            'title'        => 'Рефакторинг модуля импорта данных',
-                            'project_name' => 'MS-11 CRM',
-                            'narrative'    => 'Выполнен рефакторинг модуля импорта данных: выделен отдельный сервис для парсинга CSV-файлов, добавлена валидация входных данных.',
-                        ],
-                        [
-                            'number'       => 5,
-                            'title'        => 'Настройка CI/CD пайплайна',
-                            'project_name' => 'Infrastructure',
-                            'narrative'    => 'Настроен автоматический деплой через GitLab CI: добавлены этапы тестирования, сборки и деплоя на staging-окружение.',
-                        ],
+                    narrative: 'В понедельник выполнена основная работа по реализации модуля авторизации и начата интеграция с внешним API.',
+                ),
+                new ReportExportDay(
+                    date: '2024-01-02',
+                    tasks: [
+                        new ReportExportTask(
+                            title: 'Исправление ошибки отображения таблицы цен',
+                            projectName: 'MS-11 CRM',
+                            narrative: 'Исправлена ошибка отображения таблицы цен на мобильных устройствах. Добавлена адаптивная вёрстка для экранов шириной менее 768px.',
+                            number: 3,
+                        ),
+                        new ReportExportTask(
+                            title: 'Рефакторинг модуля импорта данных',
+                            projectName: 'MS-11 CRM',
+                            narrative: 'Выполнен рефакторинг модуля импорта данных: выделен отдельный сервис для парсинга CSV-файлов, добавлена валидация входных данных.',
+                            number: 4,
+                        ),
+                        new ReportExportTask(
+                            title: 'Настройка CI/CD пайплайна',
+                            projectName: 'Infrastructure',
+                            narrative: 'Настроен автоматический деплой через GitLab CI: добавлены этапы тестирования, сборки и деплоя на staging-окружение.',
+                            number: 5,
+                        ),
                     ],
-                ],
-                [
-                    'date'      => '2024-01-03',
-                    'narrative' => 'Завершена реализация основных функций, проведено код-ревью и написана документация.',
-                    'tasks'     => [
-                        [
-                            'number'       => 6,
-                            'title'        => 'Написание unit-тестов для сервиса авторизации',
-                            'project_name' => 'ProjectX',
-                            'narrative'    => 'Написаны unit-тесты для сервиса авторизации: покрыты основные сценарии входа, выхода и обновления токена. Покрытие кода составило 87%.',
-                        ],
-                        [
-                            'number'       => 7,
-                            'title'        => 'Обновление технической документации',
-                            'project_name' => 'ProjectX',
-                            'narrative'    => 'Обновлена техническая документация по API авторизации: добавлены примеры запросов, описаны коды ошибок и схемы данных.',
-                        ],
+                    narrative: 'Исправлены критические ошибки в модуле импорта и выполнен рефакторинг сервисного слоя.',
+                ),
+                new ReportExportDay(
+                    date: '2024-01-03',
+                    tasks: [
+                        new ReportExportTask(
+                            title: 'Написание unit-тестов для сервиса авторизации',
+                            projectName: 'ProjectX',
+                            narrative: 'Написаны unit-тесты для сервиса авторизации: покрыты основные сценарии входа, выхода и обновления токена. Покрытие кода составило 87%.',
+                            number: 6,
+                        ),
+                        new ReportExportTask(
+                            title: 'Обновление технической документации',
+                            projectName: 'ProjectX',
+                            narrative: 'Обновлена техническая документация по API авторизации: добавлены примеры запросов, описаны коды ошибок и схемы данных.',
+                            number: 7,
+                        ),
                     ],
-                ],
+                    narrative: 'Завершена реализация основных функций, проведено код-ревью и написана документация.',
+                ),
             ],
-        ];
+        );
     }
 }

--- a/backend/app/Domain/Report/DTOs/ReportExportData.php
+++ b/backend/app/Domain/Report/DTOs/ReportExportData.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Report\DTOs;
+
+final readonly class ReportExportData
+{
+    /**
+     * @param  list<ReportExportDay>  $days
+     * @param  list<ReportExportUnclassifiedCommit>|null  $unclassifiedCommits
+     */
+    public function __construct(
+        public string $type,
+        public string $developerName,
+        public string $developerPosition,
+        public string $dateFrom,
+        public string $dateTo,
+        public array $days,
+        public ?array $unclassifiedCommits = null,
+    ) {
+    }
+}

--- a/backend/app/Domain/Report/DTOs/ReportExportDay.php
+++ b/backend/app/Domain/Report/DTOs/ReportExportDay.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Report\DTOs;
+
+final readonly class ReportExportDay
+{
+    /**
+     * @param  list<ReportExportTask>  $tasks
+     */
+    public function __construct(
+        public string $date,
+        public array $tasks,
+        public ?string $narrative = null,
+    ) {
+    }
+}

--- a/backend/app/Domain/Report/DTOs/ReportExportTask.php
+++ b/backend/app/Domain/Report/DTOs/ReportExportTask.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Report\DTOs;
+
+final readonly class ReportExportTask
+{
+    public function __construct(
+        public string $title,
+        public string $projectName = '',
+        public string $narrative = '',
+        public int|string|null $number = null,
+        public ?int $id = null,
+        public ?string $status = null,
+        public ?string $bitrix24Link = null,
+    ) {
+    }
+}

--- a/backend/app/Domain/Report/DTOs/ReportExportUnclassifiedCommit.php
+++ b/backend/app/Domain/Report/DTOs/ReportExportUnclassifiedCommit.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Report\DTOs;
+
+final readonly class ReportExportUnclassifiedCommit
+{
+    public function __construct(
+        public string $repo,
+        public string $message,
+        public string $branch = '',
+    ) {
+    }
+}

--- a/backend/app/Domain/Report/Services/ReportExporterInterface.php
+++ b/backend/app/Domain/Report/Services/ReportExporterInterface.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Domain\Report\Services;
 
+use App\Domain\Report\DTOs\ReportExportData;
+
 interface ReportExporterInterface
 {
     /**
      * Export report to .docx file.
      *
-     * @param  array<string, mixed>  $reportData
      * @return string Path to generated file
      */
-    public function export(array $reportData): string;
+    public function export(ReportExportData $reportData): string;
 }

--- a/backend/app/Http/Controllers/ReportController.php
+++ b/backend/app/Http/Controllers/ReportController.php
@@ -11,6 +11,9 @@ use App\Domain\Narrative\Actions\RegenerateTaskNarrative;
 use App\Domain\Narrative\Actions\UndoDayNarrative;
 use App\Domain\Narrative\Actions\UndoTaskNarrative;
 use App\Domain\Report\Actions\GenerateReport;
+use App\Domain\Report\DTOs\ReportExportData;
+use App\Domain\Report\DTOs\ReportExportDay;
+use App\Domain\Report\DTOs\ReportExportTask;
 use App\Domain\Report\Queries\GetReportPreview;
 use App\Domain\Report\Queries\HasDataForDateRange;
 use App\Exceptions\NoDataException;
@@ -222,38 +225,38 @@ class ReportController extends Controller
         /** @var array<int, array{date: string, narrative: string|null, source: string, is_edited: bool, tasks: array<int, array{id: int|null, title: string, project_name: string|null, narrative: string|null, is_edited: bool}>}> $days */
         $days = $preview['days'];
 
-        /** @var list<array{date: string, narrative: string, tasks: list<array{number: int, title: string, project_name: string, narrative: string}>}> $mappedDays */
+        /** @var list<ReportExportDay> $mappedDays */
         $mappedDays = [];
 
         foreach ($days as $day) {
-            /** @var list<array{number: int, title: string, project_name: string, narrative: string}> $mappedTasks */
+            /** @var list<ReportExportTask> $mappedTasks */
             $mappedTasks = [];
             $taskNumber = 1;
 
             foreach ($day['tasks'] as $task) {
-                $mappedTasks[] = [
-                    'number'       => $taskNumber,
-                    'title'        => $task['title'],
-                    'project_name' => $task['project_name'] ?? '',
-                    'narrative'    => $task['narrative'] ?? '',
-                ];
+                $mappedTasks[] = new ReportExportTask(
+                    title: $task['title'],
+                    projectName: $task['project_name'] ?? '',
+                    narrative: $task['narrative'] ?? '',
+                    number: $taskNumber,
+                );
                 $taskNumber++;
             }
 
-            $mappedDays[] = [
-                'date'  => $day['date'],
-                'tasks' => $mappedTasks,
-            ];
+            $mappedDays[] = new ReportExportDay(
+                date: $day['date'],
+                tasks: $mappedTasks,
+            );
         }
 
-        $reportData = [
-            'type'               => $preview['type'],
-            'developer_name'     => $developerName,
-            'developer_position' => $developerPosition,
-            'date_from'          => $preview['date_from'],
-            'date_to'            => $preview['date_to'],
-            'days'               => $mappedDays,
-        ];
+        $reportData = new ReportExportData(
+            type: $preview['type'],
+            developerName: $developerName,
+            developerPosition: $developerPosition,
+            dateFrom: $preview['date_from'],
+            dateTo: $preview['date_to'],
+            days: $mappedDays,
+        );
 
         $filePath = $this->exporter->export($reportData);
 

--- a/backend/app/Infrastructure/Report/WordExporter.php
+++ b/backend/app/Infrastructure/Report/WordExporter.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Report;
 
+use App\Domain\Report\DTOs\ReportExportData;
+use App\Domain\Report\DTOs\ReportExportDay;
+use App\Domain\Report\DTOs\ReportExportTask;
+use App\Domain\Report\DTOs\ReportExportUnclassifiedCommit;
 use App\Domain\Report\Services\ReportExporterInterface;
 use PhpOffice\PhpWord\ComplexType\TblWidth as ComplexTblWidth;
 use PhpOffice\PhpWord\Element\Cell;
@@ -67,26 +71,18 @@ class WordExporter implements ReportExporterInterface
     /**
      * Export report to .docx file.
      *
-     * @param  array<string, mixed>  $reportData
      * @return string Path to generated file
      */
-    public function export(array $reportData): string
+    public function export(ReportExportData $reportData): string
     {
-        $type = $this->str($reportData['type'] ?? 'custom');
-
-        return match ($type) {
+        return match ($reportData->type) {
             'weekly'  => $this->exportWeekly($reportData),
             'monthly' => $this->exportMonthly($reportData),
             default   => $this->exportDefault($reportData),
         };
     }
 
-    /**
-     * Export weekly report matching report-blank.docx template exactly.
-     *
-     * @param  array<string, mixed>  $reportData
-     */
-    private function exportWeekly(array $reportData): string
+    private function exportWeekly(ReportExportData $reportData): string
     {
         $phpWord = new PhpWord();
 
@@ -113,13 +109,10 @@ class WordExporter implements ReportExporterInterface
 
         $section->addTextBreak();
 
-        $developerName = $this->str($reportData['developer_name'] ?? '_______________');
-        $developerPosition = $this->str($reportData['developer_position'] ?? '_______________');
-        $dateFrom = $this->str($reportData['date_from'] ?? '___________');
-        $dateTo = $this->str($reportData['date_to'] ?? '___________');
-
-        /** @var array<int, mixed> $rawDays */
-        $rawDays = is_array($reportData['days'] ?? null) ? $reportData['days'] : [];
+        $developerName = $reportData->developerName !== '' ? $reportData->developerName : '_______________';
+        $developerPosition = $reportData->developerPosition !== '' ? $reportData->developerPosition : '_______________';
+        $dateFrom = $reportData->dateFrom !== '' ? $reportData->dateFrom : '___________';
+        $dateTo = $reportData->dateTo !== '' ? $reportData->dateTo : '___________';
 
         $tableStyle = [
             'borderSize'  => self::WEEKLY_BORDER_SIZE,
@@ -136,7 +129,7 @@ class WordExporter implements ReportExporterInterface
         $table = $section->addTable($tableStyle);
 
         $this->addWeeklyEmployeeHeaderRow($table, $developerName, $developerPosition, $dateFrom, $dateTo, $fontStyle, $paragraphStyle);
-        $this->addWeeklyDayRows($table, $rawDays, $fontStyle, $fontBold, $paragraphStyle);
+        $this->addWeeklyDayRows($table, $reportData->days, $fontStyle, $fontBold, $paragraphStyle);
 
         return $this->saveDocument($phpWord, $reportData);
     }
@@ -164,14 +157,14 @@ class WordExporter implements ReportExporterInterface
     }
 
     /**
-     * @param  array<int, mixed>  $rawDays
+     * @param  list<ReportExportDay>  $days
      * @param  array<string, mixed>  $fontStyle
      * @param  array<string, mixed>  $fontBold
      * @param  array<string, mixed>  $paragraphStyle
      */
     private function addWeeklyDayRows(
         Table $table,
-        array $rawDays,
+        array $days,
         array $fontStyle,
         array $fontBold,
         array $paragraphStyle,
@@ -182,32 +175,20 @@ class WordExporter implements ReportExporterInterface
             $table->addRow();
             $dayCell = $table->addCell(self::WEEKLY_TABLE_WIDTH, ['valign' => 'top']);
 
-            $rawDay = $rawDays[$i] ?? null;
+            $day = $days[$i] ?? null;
 
-            /** @var array<string, mixed>|null $dayData */
-            $dayData = is_array($rawDay) ? $rawDay : null;
-
-            if ($dayData !== null) {
+            if ($day !== null) {
                 $dayName = $russianDays[$i];
-                $date = $this->str($dayData['date'] ?? '');
-                $formattedDate = $this->formatDateShort($date);
+                $formattedDate = $this->formatDateShort($day->date);
                 $this->addTextToCell($dayCell, "{$dayName}, {$formattedDate}:", $fontBold, $paragraphStyle);
 
-                /** @var array<int, mixed> $rawTasks */
-                $rawTasks = is_array($dayData['tasks'] ?? null) ? $dayData['tasks'] : [];
-
-                foreach ($rawTasks as $rawTask) {
-                    /** @var array<string, mixed> $task */
-                    $task = is_array($rawTask) ? $rawTask : [];
-                    $taskTitle = $this->str($task['title'] ?? '');
-                    $taskNarrative = $this->str($task['narrative'] ?? '');
-
-                    if ($taskTitle !== '') {
-                        $this->addTextToCell($dayCell, "• {$taskTitle}", $fontBold, $paragraphStyle);
+                foreach ($day->tasks as $task) {
+                    if ($task->title !== '') {
+                        $this->addTextToCell($dayCell, "• {$task->title}", $fontBold, $paragraphStyle);
                     }
 
-                    if ($taskNarrative !== '') {
-                        $this->addTextToCell($dayCell, "  {$taskNarrative}", $fontStyle, $paragraphStyle);
+                    if ($task->narrative !== '') {
+                        $this->addTextToCell($dayCell, "  {$task->narrative}", $fontStyle, $paragraphStyle);
                     }
                 }
             } else {
@@ -230,36 +211,20 @@ class WordExporter implements ReportExporterInterface
         $this->addTextToCell($cell, '', $fontStyle, $paragraphStyle);
     }
 
-    /**
-     * Export monthly report grouped by project.
-     *
-     * @param  array<string, mixed>  $reportData
-     */
-    private function exportMonthly(array $reportData): string
+    private function exportMonthly(ReportExportData $reportData): string
     {
         $phpWord = $this->createPhpWord();
         $section = $this->createSection($phpWord);
 
-        $developerName = $this->str($reportData['developer_name'] ?? 'Разработчик');
-        $developerPosition = $this->str($reportData['developer_position'] ?? '');
-        $dateFrom = $this->str($reportData['date_from'] ?? '');
-        $dateTo = $this->str($reportData['date_to'] ?? '');
+        $developerName = $reportData->developerName !== '' ? $reportData->developerName : 'Разработчик';
 
-        /** @var array<int, mixed> $rawDays */
-        $rawDays = is_array($reportData['days'] ?? null) ? $reportData['days'] : [];
+        $this->addMonthlyHeader($section, $developerName, $reportData->developerPosition, $reportData->dateFrom, $reportData->dateTo);
 
-        $this->addMonthlyHeader($section, $developerName, $developerPosition, $dateFrom, $dateTo);
-
-        $grouped = $this->groupTasksByProject($rawDays);
-        $this->addStatsLine($section, $grouped['totalTasks'], count($rawDays));
+        $grouped = $this->groupTasksByProject($reportData->days);
+        $this->addStatsLine($section, $grouped['totalTasks'], count($reportData->days));
         $this->addProjectSections($section, $grouped['tasksByProject']);
 
-        /** @var array<int, mixed> $rawUnclassified */
-        $rawUnclassified = is_array($reportData['unclassified_commits'] ?? null)
-            ? $reportData['unclassified_commits']
-            : [];
-
-        $this->addUnclassifiedCommitsSection($section, $rawUnclassified);
+        $this->addUnclassifiedCommitsSection($section, $reportData->unclassifiedCommits ?? []);
 
         return $this->saveDocument($phpWord, $reportData);
     }
@@ -293,37 +258,24 @@ class WordExporter implements ReportExporterInterface
     }
 
     /**
-     * @param  array<int, mixed>  $rawDays
-     * @return array{tasksByProject: array<string, array<int, array<string, mixed>>>, totalTasks: int}
+     * @param  list<ReportExportDay>  $days
+     * @return array{tasksByProject: array<string, list<ReportExportTask>>, totalTasks: int}
      */
-    private function groupTasksByProject(array $rawDays): array
+    private function groupTasksByProject(array $days): array
     {
-        /** @var array<string, array<int, array<string, mixed>>> $tasksByProject */
+        /** @var array<string, list<ReportExportTask>> $tasksByProject */
         $tasksByProject = [];
         $totalTasks = 0;
 
-        foreach ($rawDays as $rawDay) {
-            /** @var array<string, mixed> $day */
-            $day = is_array($rawDay) ? $rawDay : [];
+        foreach ($days as $day) {
+            foreach ($day->tasks as $task) {
+                $projectName = $task->projectName !== '' ? $task->projectName : 'Без проекта';
 
-            /** @var array<int, mixed> $rawTasks */
-            $rawTasks = is_array($day['tasks'] ?? null) ? $day['tasks'] : [];
-
-            foreach ($rawTasks as $rawTask) {
-                /** @var array<string, mixed> $task */
-                $task = is_array($rawTask) ? $rawTask : [];
-
-                $projectNameRaw = $task['project_name'] ?? null;
-                $projectName = is_string($projectNameRaw) && $projectNameRaw !== ''
-                    ? $projectNameRaw
-                    : 'Без проекта';
-
-                $taskTitle = $this->str($task['title'] ?? '');
                 $alreadyAdded = false;
 
                 if (isset($tasksByProject[$projectName])) {
                     foreach ($tasksByProject[$projectName] as $existing) {
-                        if ($this->str($existing['title'] ?? '') === $taskTitle) {
+                        if ($existing->title === $task->title) {
                             $alreadyAdded = true;
                             break;
                         }
@@ -350,7 +302,7 @@ class WordExporter implements ReportExporterInterface
     }
 
     /**
-     * @param  array<string, array<int, array<string, mixed>>>  $tasksByProject
+     * @param  array<string, list<ReportExportTask>>  $tasksByProject
      */
     private function addProjectSections(Section $section, array $tasksByProject): void
     {
@@ -380,7 +332,7 @@ class WordExporter implements ReportExporterInterface
     }
 
     /**
-     * @param  array<int, array<string, mixed>>  $tasks
+     * @param  list<ReportExportTask>  $tasks
      */
     private function addTasksByStatus(
         Section $section,
@@ -398,7 +350,7 @@ class WordExporter implements ReportExporterInterface
         $hasEntries = false;
 
         foreach ($tasks as $task) {
-            $isCompleted = $this->str($task['status'] ?? '') === 'completed';
+            $isCompleted = ($task->status ?? '') === 'completed';
 
             if ($completed !== $isCompleted) {
                 continue;
@@ -418,11 +370,11 @@ class WordExporter implements ReportExporterInterface
     }
 
     /**
-     * @param  array<int, mixed>  $rawUnclassified
+     * @param  list<ReportExportUnclassifiedCommit>  $unclassifiedCommits
      */
-    private function addUnclassifiedCommitsSection(Section $section, array $rawUnclassified): void
+    private function addUnclassifiedCommitsSection(Section $section, array $unclassifiedCommits): void
     {
-        if ($rawUnclassified === []) {
+        if ($unclassifiedCommits === []) {
             return;
         }
 
@@ -436,17 +388,11 @@ class WordExporter implements ReportExporterInterface
 
         $this->addSeparatorLine($section, spaceBefore: 0, spaceAfter: 120);
 
-        foreach ($rawUnclassified as $rawCommit) {
-            /** @var array<string, mixed> $commit */
-            $commit = is_array($rawCommit) ? $rawCommit : [];
-            $repo = $this->str($commit['repo'] ?? '');
-            $message = $this->str($commit['message'] ?? '');
-            $branch = $this->str($commit['branch'] ?? '');
+        foreach ($unclassifiedCommits as $commit) {
+            $line = "• [repo: {$commit->repo}] {$commit->message}";
 
-            $line = "• [repo: {$repo}] {$message}";
-
-            if ($branch !== '') {
-                $line .= " (branch: {$branch})";
+            if ($commit->branch !== '') {
+                $line .= " (branch: {$commit->branch})";
             }
 
             $section->addText(
@@ -457,50 +403,34 @@ class WordExporter implements ReportExporterInterface
         }
     }
 
-    /**
-     * Add a single task entry in monthly report format.
-     *
-     * @param  array<string, mixed>  $task
-     */
-    private function addMonthlyTaskEntry(Section $section, array $task): void
+    private function addMonthlyTaskEntry(Section $section, ReportExportTask $task): void
     {
-        $taskIdRaw = $task['id'] ?? null;
-        $taskId = $taskIdRaw !== null ? $this->str($taskIdRaw) : '';
-        $title = $this->str($task['title'] ?? '');
-        $narrative = $this->str($task['narrative'] ?? '');
-        $link = $this->str($task['bitrix24_link'] ?? '');
-
-        $idPrefix = $taskId !== '' ? "Задача #{$taskId} — " : '';
+        $idPrefix = $task->id !== null ? "Задача #{$task->id} — " : '';
 
         $section->addText(
-            "  • {$idPrefix}{$title}",
+            "  • {$idPrefix}{$task->title}",
             ['name'       => self::FONT_MAIN, 'size' => self::SIZE_MAIN / 2, 'bold' => true],
             ['spaceAfter' => 0, 'indentation' => ['left' => self::INDENT_FIRST_LINE]]
         );
 
-        if ($link !== '') {
+        if ($task->bitrix24Link !== null && $task->bitrix24Link !== '') {
             $section->addText(
-                "    {$link}",
+                "    {$task->bitrix24Link}",
                 ['name'       => self::FONT_MAIN, 'size' => self::SIZE_MAIN / 2],
                 ['spaceAfter' => 0, 'indentation' => ['left' => self::INDENT_FIRST_LINE]]
             );
         }
 
-        if ($narrative !== '') {
+        if ($task->narrative !== '') {
             $section->addText(
-                "    {$narrative}",
+                "    {$task->narrative}",
                 ['name'       => self::FONT_MAIN, 'size' => self::SIZE_MAIN / 2],
                 ['spaceAfter' => 60, 'indentation' => ['left' => self::INDENT_FIRST_LINE]]
             );
         }
     }
 
-    /**
-     * Export default report (daily / custom) — original format with task tables.
-     *
-     * @param  array<string, mixed>  $reportData
-     */
-    private function exportDefault(array $reportData): string
+    private function exportDefault(ReportExportData $reportData): string
     {
         $phpWord = $this->createPhpWord();
         $section = $this->createSection($phpWord);
@@ -541,16 +471,8 @@ class WordExporter implements ReportExporterInterface
         ]);
     }
 
-    /**
-     * @param  array<string, mixed>  $reportData
-     */
-    private function addHeader(Section $section, array $reportData): void
+    private function addHeader(Section $section, ReportExportData $reportData): void
     {
-        $developerName = $this->str($reportData['developer_name'] ?? '');
-        $developerPosition = $this->str($reportData['developer_position'] ?? '');
-        $dateFrom = $this->str($reportData['date_from'] ?? '');
-        $dateTo = $this->str($reportData['date_to'] ?? '');
-
         $titleParagraph = $section->addTextRun([
             'alignment'  => Jc::CENTER,
             'spaceAfter' => 120,
@@ -569,7 +491,7 @@ class WordExporter implements ReportExporterInterface
             'spaceAfter' => 120,
         ]);
         $periodParagraph->addText(
-            'Период: ' . $dateFrom . ' — ' . $dateTo,
+            'Период: ' . $reportData->dateFrom . ' — ' . $reportData->dateTo,
             [
                 'name' => self::FONT_MAIN,
                 'size' => self::SIZE_MAIN / 2,
@@ -581,7 +503,7 @@ class WordExporter implements ReportExporterInterface
             'spaceAfter' => 240,
         ]);
         $developerParagraph->addText(
-            'Разработчик: ' . $developerName . ', ' . $developerPosition,
+            'Разработчик: ' . $reportData->developerName . ', ' . $reportData->developerPosition,
             [
                 'name' => self::FONT_MAIN,
                 'size' => self::SIZE_MAIN / 2,
@@ -589,42 +511,21 @@ class WordExporter implements ReportExporterInterface
         );
     }
 
-    /**
-     * @param  array<string, mixed>  $reportData
-     */
-    private function addDays(Section $section, array $reportData): void
+    private function addDays(Section $section, ReportExportData $reportData): void
     {
-        /** @var array<int, mixed> $rawDays */
-        $rawDays = is_array($reportData['days'] ?? null) ? $reportData['days'] : [];
-
-        foreach ($rawDays as $rawDay) {
-            /** @var array<string, mixed> $day */
-            $day = is_array($rawDay) ? $rawDay : [];
+        foreach ($reportData->days as $day) {
             $this->addDaySection($section, $day);
         }
     }
 
-    /**
-     * @param  array<string, mixed>  $day
-     */
-    private function addDaySection(Section $section, array $day): void
+    private function addDaySection(Section $section, ReportExportDay $day): void
     {
-        $date = $this->str($day['date'] ?? '');
-        /** @var array<int, mixed> $rawTasks */
-        $rawTasks = is_array($day['tasks'] ?? null) ? $day['tasks'] : [];
-
-        /** @var array<int, array<string, mixed>> $tasks */
-        $tasks = array_values(array_filter(
-            array_map(static fn (mixed $t): mixed => is_array($t) ? $t : null, $rawTasks),
-            static fn (mixed $t): bool => $t !== null,
-        ));
-
         $dayHeading = $section->addTextRun([
             'spaceAfter'  => 120,
             'spaceBefore' => 240,
         ]);
         $dayHeading->addText(
-            $this->formatDate($date),
+            $this->formatDate($day->date),
             [
                 'name' => self::FONT_MAIN,
                 'size' => self::SIZE_HEADING2 / 2,
@@ -632,13 +533,13 @@ class WordExporter implements ReportExporterInterface
             ]
         );
 
-        if ($tasks !== []) {
-            $this->addTasksTable($section, $tasks);
+        if ($day->tasks !== []) {
+            $this->addTasksTable($section, $day->tasks);
         }
     }
 
     /**
-     * @param  array<int, array<string, mixed>>  $tasks
+     * @param  list<ReportExportTask>  $tasks
      */
     private function addTasksTable(Section $section, array $tasks): void
     {
@@ -681,36 +582,22 @@ class WordExporter implements ReportExporterInterface
         $headerRow->addCell(null, $headerCellStyle)->addText('Описание работ', $headerFontStyle, $cellParagraphStyle);
 
         foreach ($tasks as $task) {
-            $number = $this->str($task['number'] ?? '');
-            $title = $this->str($task['title'] ?? '');
-            $projectName = $this->str($task['project_name'] ?? '');
-            $taskNarrative = $this->str($task['narrative'] ?? '');
+            $number = $task->number !== null ? (string) $task->number : '';
 
             $row = $table->addRow();
             $row->addCell(500)->addText($number, $cellFontStyle, $cellParagraphStyle);
-            $row->addCell(3000)->addText($title, $cellFontStyle, $cellParagraphStyle);
-            $row->addCell(2000)->addText($projectName, $cellFontStyle, $cellParagraphStyle);
-            $row->addCell(null)->addText($taskNarrative, $cellFontStyle, $cellParagraphStyle);
+            $row->addCell(3000)->addText($task->title, $cellFontStyle, $cellParagraphStyle);
+            $row->addCell(2000)->addText($task->projectName, $cellFontStyle, $cellParagraphStyle);
+            $row->addCell(null)->addText($task->narrative, $cellFontStyle, $cellParagraphStyle);
         }
     }
 
-    /**
-     * @param  array<string, mixed>  $reportData
-     */
-    private function addSummary(Section $section, array $reportData): void
+    private function addSummary(Section $section, ReportExportData $reportData): void
     {
-        /** @var array<int, mixed> $rawDays */
-        $rawDays = is_array($reportData['days'] ?? null) ? $reportData['days'] : [];
-
         $totalTasks = 0;
 
-        foreach ($rawDays as $rawDay) {
-            /** @var array<string, mixed> $day */
-            $day = is_array($rawDay) ? $rawDay : [];
-
-            /** @var array<int, mixed> $dayTasks */
-            $dayTasks = is_array($day['tasks'] ?? null) ? $day['tasks'] : [];
-            $totalTasks += count($dayTasks);
+        foreach ($reportData->days as $day) {
+            $totalTasks += count($day->tasks);
         }
 
         $summaryHeading = $section->addTextRun([
@@ -731,7 +618,7 @@ class WordExporter implements ReportExporterInterface
             'spaceAfter'  => 120,
         ]);
         $statsParagraph->addText(
-            'Всего задач: ' . $totalTasks . '   |   Рабочих дней: ' . count($rawDays),
+            'Всего задач: ' . $totalTasks . '   |   Рабочих дней: ' . count($reportData->days),
             [
                 'name' => self::FONT_MAIN,
                 'size' => self::SIZE_MAIN / 2,
@@ -739,10 +626,7 @@ class WordExporter implements ReportExporterInterface
         );
     }
 
-    /**
-     * @param  array<string, mixed>  $reportData
-     */
-    private function saveDocument(PhpWord $phpWord, array $reportData): string
+    private function saveDocument(PhpWord $phpWord, ReportExportData $reportData): string
     {
         $reportsDir = storage_path('app/reports');
 
@@ -750,8 +634,8 @@ class WordExporter implements ReportExporterInterface
             throw new RuntimeException('Failed to create reports directory: ' . $reportsDir);
         }
 
-        $dateFrom = $this->str($reportData['date_from'] ?? 'unknown');
-        $dateTo = $this->str($reportData['date_to'] ?? 'unknown');
+        $dateFrom = $reportData->dateFrom !== '' ? $reportData->dateFrom : 'unknown';
+        $dateTo = $reportData->dateTo !== '' ? $reportData->dateTo : 'unknown';
         $filename = 'report-' . $dateFrom . '-' . $dateTo . '.docx';
         $filePath = $reportsDir . DIRECTORY_SEPARATOR . $filename;
 
@@ -770,22 +654,6 @@ class WordExporter implements ReportExporterInterface
     private function addTextToCell(Cell $cell, string $text, array $fontStyle, array $paragraphStyle): void
     {
         $cell->addText($text, $fontStyle, $paragraphStyle);
-    }
-
-    /**
-     * Safely convert a mixed value to string.
-     */
-    private function str(mixed $value): string
-    {
-        if (is_string($value)) {
-            return $value;
-        }
-
-        if (is_int($value) || is_float($value) || is_bool($value)) {
-            return (string) $value;
-        }
-
-        return '';
     }
 
     private function formatDate(string $date): string

--- a/backend/tests/Feature/Report/WordExportSmokeTest.php
+++ b/backend/tests/Feature/Report/WordExportSmokeTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Report;
 
+use App\Domain\Report\DTOs\ReportExportData;
+use App\Domain\Report\DTOs\ReportExportDay;
+use App\Domain\Report\DTOs\ReportExportTask;
 use App\Infrastructure\Report\WordExporter;
 use PhpOffice\PhpWord\Element\AbstractElement;
 use PhpOffice\PhpWord\Element\Section;
@@ -20,42 +23,26 @@ class WordExportSmokeTest extends TestCase
     {
         $exporter = new WordExporter();
 
-        $reportData = [
-            'type'               => 'weekly',
-            'developer_name'     => 'Иванов Иван Иванович',
-            'developer_position' => 'Разработчик',
-            'date_from'          => '2026-03-09',
-            'date_to'            => '2026-03-13',
-            'days'               => [
-                [
-                    'date'      => '2026-03-09',
-                    'narrative' => 'Работал над авторизацией.',
-                    'tasks'     => [
-                        ['title' => 'Задача авторизации', 'narrative' => 'Реализована JWT-авторизация.'],
+        $reportData = new ReportExportData(
+            type: 'weekly',
+            developerName: 'Иванов Иван Иванович',
+            developerPosition: 'Разработчик',
+            dateFrom: '2026-03-09',
+            dateTo: '2026-03-13',
+            days: [
+                new ReportExportDay(
+                    date: '2026-03-09',
+                    tasks: [
+                        new ReportExportTask(title: 'Задача авторизации', narrative: 'Реализована JWT-авторизация.'),
                     ],
-                ],
-                [
-                    'date'      => '2026-03-10',
-                    'narrative' => 'Рефакторинг модулей.',
-                    'tasks'     => [],
-                ],
-                [
-                    'date'      => '2026-03-11',
-                    'narrative' => 'Покрытие тестами.',
-                    'tasks'     => [],
-                ],
-                [
-                    'date'      => '2026-03-12',
-                    'narrative' => 'Ревью кода коллег.',
-                    'tasks'     => [],
-                ],
-                [
-                    'date'      => '2026-03-13',
-                    'narrative' => 'Деплой на staging.',
-                    'tasks'     => [],
-                ],
+                    narrative: 'Работал над авторизацией.',
+                ),
+                new ReportExportDay(date: '2026-03-10', tasks: [], narrative: 'Рефакторинг модулей.'),
+                new ReportExportDay(date: '2026-03-11', tasks: [], narrative: 'Покрытие тестами.'),
+                new ReportExportDay(date: '2026-03-12', tasks: [], narrative: 'Ревью кода коллег.'),
+                new ReportExportDay(date: '2026-03-13', tasks: [], narrative: 'Деплой на staging.'),
             ],
-        ];
+        );
 
         $filePath = $exporter->export($reportData);
         $this->generatedFiles[] = $filePath;
@@ -127,38 +114,38 @@ class WordExportSmokeTest extends TestCase
     {
         $exporter = new WordExporter();
 
-        $reportData = [
-            'type'               => 'monthly',
-            'developer_name'     => 'Петров Пётр Петрович',
-            'developer_position' => 'Senior Developer',
-            'date_from'          => '2026-03-01',
-            'date_to'            => '2026-03-31',
-            'days'               => [
-                [
-                    'date'      => '2026-03-03',
-                    'narrative' => 'Выполнена работа по проекту.',
-                    'tasks'     => [
-                        [
-                            'id'            => 101,
-                            'title'         => 'Реализация API авторизации',
-                            'project_name'  => 'CRM-System',
-                            'narrative'     => 'Разработан REST API для авторизации.',
-                            'status'        => 'completed',
-                            'bitrix24_link' => 'https://bitrix.example.com/tasks/101',
-                        ],
-                        [
-                            'id'            => 102,
-                            'title'         => 'Оптимизация запросов к БД',
-                            'project_name'  => 'CRM-System',
-                            'narrative'     => 'Оптимизированы медленные SQL-запросы.',
-                            'status'        => 'in_progress',
-                            'bitrix24_link' => '',
-                        ],
+        $reportData = new ReportExportData(
+            type: 'monthly',
+            developerName: 'Петров Пётр Петрович',
+            developerPosition: 'Senior Developer',
+            dateFrom: '2026-03-01',
+            dateTo: '2026-03-31',
+            days: [
+                new ReportExportDay(
+                    date: '2026-03-03',
+                    tasks: [
+                        new ReportExportTask(
+                            title: 'Реализация API авторизации',
+                            projectName: 'CRM-System',
+                            narrative: 'Разработан REST API для авторизации.',
+                            id: 101,
+                            status: 'completed',
+                            bitrix24Link: 'https://bitrix.example.com/tasks/101',
+                        ),
+                        new ReportExportTask(
+                            title: 'Оптимизация запросов к БД',
+                            projectName: 'CRM-System',
+                            narrative: 'Оптимизированы медленные SQL-запросы.',
+                            id: 102,
+                            status: 'in_progress',
+                            bitrix24Link: '',
+                        ),
                     ],
-                ],
+                    narrative: 'Выполнена работа по проекту.',
+                ),
             ],
-            'unclassified_commits' => [],
-        ];
+            unclassifiedCommits: [],
+        );
 
         $filePath = $exporter->export($reportData);
         $this->generatedFiles[] = $filePath;
@@ -180,27 +167,27 @@ class WordExportSmokeTest extends TestCase
     {
         $exporter = new WordExporter();
 
-        $reportData = [
-            'type'               => 'daily',
-            'developer_name'     => 'Сидоров Сидор Сидорович',
-            'developer_position' => 'Backend Developer',
-            'date_from'          => '2026-03-10',
-            'date_to'            => '2026-03-10',
-            'days'               => [
-                [
-                    'date'      => '2026-03-10',
-                    'narrative' => 'Выполнена разработка модуля уведомлений.',
-                    'tasks'     => [
-                        [
-                            'number'       => 1,
-                            'title'        => 'Модуль уведомлений',
-                            'project_name' => 'MainProject',
-                            'narrative'    => 'Реализован сервис email-уведомлений.',
-                        ],
+        $reportData = new ReportExportData(
+            type: 'daily',
+            developerName: 'Сидоров Сидор Сидорович',
+            developerPosition: 'Backend Developer',
+            dateFrom: '2026-03-10',
+            dateTo: '2026-03-10',
+            days: [
+                new ReportExportDay(
+                    date: '2026-03-10',
+                    tasks: [
+                        new ReportExportTask(
+                            title: 'Модуль уведомлений',
+                            projectName: 'MainProject',
+                            narrative: 'Реализован сервис email-уведомлений.',
+                            number: 1,
+                        ),
                     ],
-                ],
+                    narrative: 'Выполнена разработка модуля уведомлений.',
+                ),
             ],
-        ];
+        );
 
         $filePath = $exporter->export($reportData);
         $this->generatedFiles[] = $filePath;
@@ -213,14 +200,14 @@ class WordExportSmokeTest extends TestCase
     {
         $exporter = new WordExporter();
 
-        $reportData = [
-            'type'               => 'weekly',
-            'developer_name'     => 'Козлов Козёл Козлович',
-            'developer_position' => 'Developer',
-            'date_from'          => '2026-03-09',
-            'date_to'            => '2026-03-13',
-            'days'               => [],
-        ];
+        $reportData = new ReportExportData(
+            type: 'weekly',
+            developerName: 'Козлов Козёл Козлович',
+            developerPosition: 'Developer',
+            dateFrom: '2026-03-09',
+            dateTo: '2026-03-13',
+            days: [],
+        );
 
         $filePath = $exporter->export($reportData);
         $this->generatedFiles[] = $filePath;


### PR DESCRIPTION
Introduce ReportExportData, ReportExportDay, ReportExportTask, and ReportExportUnclassifiedCommit DTOs to replace loosely-typed arrays flowing through WordExporter. This eliminates defensive is_array() guards, enables IDE autocompletion, and enforces the data contract at compile time via PHPStan.

Closes #18 