### PR TITLE
refactor: extract toResponseData helper from SettingsController::index

### DIFF
--- a/backend/app/Http/Controllers/SettingsController.php
+++ b/backend/app/Http/Controllers/SettingsController.php
@@ -16,37 +16,7 @@ class SettingsController extends Controller
         /** @var Setting|null $settings */
         $settings = Setting::query()->first();
 
-        if ($settings === null) {
-            return response()->json([
-                'gitlab_username'         => null,
-                'gitlab_email'            => null,
-                'bitrix24_user_id'        => null,
-                'llm_provider'            => LlmProvider::Claude->value,
-                'llm_system_prompt'       => null,
-                'developer_name'          => null,
-                'developer_position'      => null,
-                'enriched_prompt_enabled' => true,
-                'sync_schedule_time'      => '03:00',
-                'has_gitlab_token'        => false,
-                'has_bitrix24_api_key'    => false,
-                'has_llm_api_key'         => false,
-            ]);
-        }
-
-        return response()->json([
-            'gitlab_username'         => $settings->gitlab_username,
-            'gitlab_email'            => $settings->gitlab_email,
-            'bitrix24_user_id'        => $settings->bitrix24_user_id,
-            'llm_provider'            => $settings->llm_provider?->value,
-            'llm_system_prompt'       => $settings->llm_system_prompt,
-            'enriched_prompt_enabled' => $settings->enriched_prompt_enabled,
-            'developer_name'          => $settings->developer_name,
-            'developer_position'      => $settings->developer_position,
-            'sync_schedule_time'      => $settings->sync_schedule_time,
-            'has_gitlab_token'        => $settings->gitlab_token !== null,
-            'has_bitrix24_api_key'    => $settings->bitrix24_api_key !== null,
-            'has_llm_api_key'         => $settings->llm_api_key !== null,
-        ]);
+        return response()->json($this->toResponseData($settings));
     }
 
     public function update(UpdateSettingsRequest $request): JsonResponse
@@ -65,5 +35,28 @@ class SettingsController extends Controller
         }
 
         return response()->json(['message' => 'Settings updated']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toResponseData(?Setting $settings): array
+    {
+        return [
+            'gitlab_username'  => $settings?->gitlab_username,
+            'gitlab_email'     => $settings?->gitlab_email,
+            'bitrix24_user_id' => $settings?->bitrix24_user_id,
+            'llm_provider'     => $settings === null
+                ? LlmProvider::Claude->value
+                : $settings->llm_provider?->value,
+            'llm_system_prompt'       => $settings?->llm_system_prompt,
+            'developer_name'          => $settings?->developer_name,
+            'developer_position'      => $settings?->developer_position,
+            'enriched_prompt_enabled' => $settings === null ? true : $settings->enriched_prompt_enabled,
+            'sync_schedule_time'      => $settings === null ? '03:00' : $settings->sync_schedule_time,
+            'has_gitlab_token'        => $settings?->gitlab_token !== null,
+            'has_bitrix24_api_key'    => $settings?->bitrix24_api_key !== null,
+            'has_llm_api_key'         => $settings?->llm_api_key !== null,
+        ];
     }
 }


### PR DESCRIPTION
Remove duplicated 12-field JSON structure across the null/non-null Setting branches. Defaults (llm_provider=Claude, enriched_prompt_enabled=true, sync_schedule_time='03:00') are preserved byte-exact through explicit ternaries; remaining fields flow through null-safe operators.