### PR TITLE
fix(sync): keep SSE stream alive and auto-refresh UI after job completes

### DIFF
--- a/backend/app/Http/Controllers/SyncController.php
+++ b/backend/app/Http/Controllers/SyncController.php
@@ -104,8 +104,25 @@ class SyncController extends Controller
                 ob_end_clean();
             }
 
-            $this->sendCurrentJobState();
-            $this->listenForProgressOnDedicatedConnection();
+            /** @var SyncJob|null $currentJob */
+            $currentJob = SyncJob::query()->latest('started_at')->first();
+
+            $this->sendInitialState($currentJob);
+
+            if ($currentJob === null) {
+                return;
+            }
+
+            if (in_array($currentJob->status, [SyncStatus::Success, SyncStatus::Failed], true)) {
+                $this->sendSSE('done', [
+                    'status'        => $currentJob->status->value,
+                    'error_message' => $currentJob->error_message,
+                ]);
+
+                return;
+            }
+
+            $this->listenForProgressOnDedicatedConnection($currentJob->id);
         }, 200, [
             'Content-Type'      => 'text/event-stream',
             'Cache-Control'     => 'no-cache',
@@ -120,24 +137,58 @@ class SyncController extends Controller
      * Uses a separate connection because disconnect() is the only way
      * to exit phpredis' blocking subscribe() — and it throws RedisException.
      */
-    private function listenForProgressOnDedicatedConnection(): void
+    private function listenForProgressOnDedicatedConnection(int $syncJobId): void
     {
         /** @var PhpRedisConnection $redis */
         $redis = Redis::connection('subscribe');
 
-        try {
-            $redis->subscribe(['sync:progress'], function (string $message) use ($redis): void {
-                /** @var array<string, mixed> $data */
-                $data = json_decode($message, true);
-                $this->sendSSE('progress', $data);
+        while (! connection_aborted()) {
+            $subscribedNormally = false;
+            try {
+                $redis->subscribe(['sync:progress'], function (string $message) use ($redis, &$subscribedNormally): void {
+                    $subscribedNormally = true;
+                    /** @var array<string, mixed> $data */
+                    $data = json_decode($message, true);
+                    $this->sendSSE('progress', $data);
 
-                $status = $data['status'] ?? null;
-                if ($status === 'success' || $status === 'failed') {
-                    $this->sendSSE('done', ['status' => $status]);
-                    $redis->disconnect();
+                    $status = $data['status'] ?? null;
+                    if ($status === 'success' || $status === 'failed') {
+                        $this->sendSSE('done', [
+                            'status'        => $status,
+                            'error_message' => $data['error_message'] ?? null,
+                        ]);
+                        $redis->disconnect();
+                    }
+                });
+
+                if ($subscribedNormally) {
+                    break;
                 }
-            });
-        } catch (RedisException) {
+            } catch (RedisException) {
+                // read_timeout — fall through to DB re-check.
+            }
+
+            /** @var SyncJob|null $fresh */
+            $fresh = SyncJob::find($syncJobId);
+            if ($fresh !== null && in_array($fresh->status, [SyncStatus::Success, SyncStatus::Failed], true)) {
+                $this->sendSSE('done', [
+                    'status'        => $fresh->status->value,
+                    'error_message' => $fresh->error_message,
+                ]);
+                break;
+            }
+
+            $this->sendHeartbeat();
+            if (connection_aborted()) {
+                break;
+            }
+
+            // After a read timeout, phpredis leaves the subscribe connection in a state
+            // where the next subscribe() call returns immediately with no events. Purge the
+            // cached singleton so Redis::connection() produces a fresh phpredis client.
+            Redis::purge('subscribe');
+            /** @var PhpRedisConnection $redis */
+            $redis = Redis::connection('subscribe');
         }
     }
 
@@ -152,22 +203,30 @@ class SyncController extends Controller
         return true;
     }
 
-    private function sendCurrentJobState(): void
+    private function sendInitialState(?SyncJob $job): void
     {
-        /** @var SyncJob|null $currentJob */
-        $currentJob = SyncJob::query()
-            ->latest('started_at')
-            ->first();
-
-        if ($currentJob !== null) {
-            $this->sendSSE('state', [
-                'status'        => $currentJob->status->value,
-                'current_step'  => $currentJob->current_step?->value,
-                'error_message' => $currentJob->error_message,
-            ]);
-        } else {
+        if ($job === null) {
             $this->sendSSE('state', ['status' => 'never']);
+
+            return;
         }
+
+        $this->sendSSE('state', [
+            'status'        => $job->status->value,
+            'current_step'  => $job->current_step?->value,
+            'error_message' => $job->error_message,
+        ]);
+    }
+
+    private function sendHeartbeat(): void
+    {
+        echo ": ping\n\n";
+
+        if (connection_aborted()) {
+            return;
+        }
+
+        flush();
     }
 
     /**

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -180,12 +180,13 @@ return [
         ],
 
         'subscribe' => [
-            'url'      => env('REDIS_URL'),
-            'host'     => env('REDIS_HOST', '127.0.0.1'),
-            'username' => env('REDIS_USERNAME'),
-            'password' => env('REDIS_PASSWORD'),
-            'port'     => env('REDIS_PORT', '6379'),
-            'database' => env('REDIS_DB', '0'),
+            'url'          => env('REDIS_URL'),
+            'host'         => env('REDIS_HOST', '127.0.0.1'),
+            'username'     => env('REDIS_USERNAME'),
+            'password'     => env('REDIS_PASSWORD'),
+            'port'         => env('REDIS_PORT', '6379'),
+            'database'     => env('REDIS_DB', '0'),
+            'read_timeout' => 10,
         ],
 
     ],

--- a/frontend/src/components/sync/SyncButton.tsx
+++ b/frontend/src/components/sync/SyncButton.tsx
@@ -26,9 +26,11 @@ export function SyncButton() {
   const handleSync = async () => {
     try {
       await triggerSync.mutateAsync();
+      queryClient.invalidateQueries({ queryKey: ["sync-status"] });
       connect();
     } catch (e) {
       if (ApiError.isApiError(e) && e.status === 409) {
+        queryClient.invalidateQueries({ queryKey: ["sync-status"] });
         connect();
       }
     }

--- a/frontend/src/hooks/useSync.ts
+++ b/frontend/src/hooks/useSync.ts
@@ -5,6 +5,8 @@ export function useSyncStatus() {
   return useQuery({
     queryKey: ["sync-status"],
     queryFn: syncApi.status,
+    refetchInterval: (query) =>
+      query.state.data?.status === "in_progress" ? 3000 : false,
   });
 }
 

--- a/frontend/src/hooks/useSyncSSE.ts
+++ b/frontend/src/hooks/useSyncSSE.ts
@@ -6,11 +6,21 @@ interface SyncProgress {
   error_message?: string | null;
 }
 
+const MAX_RETRIES = 5;
+
 export function useSyncSSE() {
   const [progress, setProgress] = useState<SyncProgress | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const disconnectedByUserRef = useRef<boolean>(false);
+  const retryCountRef = useRef<number>(0);
+  const reconnectTimerRef = useRef<number | null>(null);
 
   const connect = useCallback(() => {
+    disconnectedByUserRef.current = false;
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
     eventSourceRef.current?.close();
 
     const es = new EventSource("/api/sync/stream");
@@ -19,8 +29,12 @@ export function useSyncSSE() {
     const handleEvent = (event: MessageEvent) => {
       const data: SyncProgress = JSON.parse(event.data);
       setProgress(data);
+      // reset backoff on any event so transient blips don't exhaust retries
+      retryCountRef.current = 0;
 
       if (data.status === "success" || data.status === "failed") {
+        // suppress reconnect after clean server close on terminal status
+        disconnectedByUserRef.current = true;
         es.close();
         eventSourceRef.current = null;
       }
@@ -33,10 +47,22 @@ export function useSyncSSE() {
     es.onerror = () => {
       es.close();
       eventSourceRef.current = null;
+      if (disconnectedByUserRef.current) return;
+      if (retryCountRef.current >= MAX_RETRIES) return;
+      const delay = Math.min(2000 * 2 ** retryCountRef.current, 15000);
+      retryCountRef.current += 1;
+      reconnectTimerRef.current = window.setTimeout(() => {
+        connect();
+      }, delay);
     };
   }, []);
 
   const disconnect = useCallback(() => {
+    disconnectedByUserRef.current = true;
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
     eventSourceRef.current?.close();
     eventSourceRef.current = null;
     setProgress(null);
@@ -45,6 +71,10 @@ export function useSyncSSE() {
   useEffect(() => {
     return () => {
       eventSourceRef.current?.close();
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
     };
   }, []);
 


### PR DESCRIPTION
Sync button got stuck in "Синхронизация: GitLab..." until manual reload. Root cause: phpredis subscribe() hit PHP default_socket_timeout=60 and the controller silently swallowed the exception, ending the stream; frontend had neither reconnect nor a polling fallback. Between gitlab→bitrix24 steps there are minutes of silence, so the stream always died mid-sync.

Backend: add read_timeout=10 on the subscribe Redis connection, replace the silent catch with a loop that re-checks SyncJob in DB, emits SSE heartbeats and purges the phpredis singleton before re-subscribing (after a read timeout phpredis leaves the cached connection in a state where subscribe() returns immediately with no events). Emit done early if the latest job is already terminal so late subscribers exit cleanly.

Frontend: add exponential-backoff reconnect to useSyncSSE (2→4→8→15s, cap 5), enable refetchInterval on useSyncStatus while status is in_progress, and invalidate sync-status right after trigger so the poll loop engages before SSE delivers anything.

Closes #26 