### PR TITLE
docs: align AGENTS, READMEs and CONTRIBUTING with DDD architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,28 +54,59 @@ docker compose exec node sh -c "cd /app && npx eslint src/"
 
 - `declare(strict_types=1)` в каждом PHP-файле
 - Типизированные параметры, возвраты и свойства — без `mixed`, без подавления ошибок через `@phpstan-ignore`
-- Каждый сервис реализует интерфейс (например `SyncServiceInterface` → `SyncService`)
-- Enum-ы для всех перечислимых значений (см. `backend/app/Enums/`)
-- DTO через readonly-классы (см. `backend/app/DTOs/`)
+- Архитектура — DDD: `backend/app/Domain/<Context>/` для бизнес-логики, `backend/app/Infrastructure/<Context>/` для адаптеров к внешним системам (см. раздел «Доменный и инфраструктурный слои»)
+- Use Cases оформляются как `final readonly` Action-классы с одним публичным методом `__invoke()` (см. `Domain/<Context>/Actions/`)
+- Внешние клиенты реализуют интерфейс из `Domain/<Context>/Services/` (например, `Bitrix24ClientInterface` → `Infrastructure/Bitrix24/Bitrix24Client`)
+- Enum-ы для всех перечислимых значений (см. `Domain/<Context>/Enums/`)
+- DTO через `readonly`-классы (см. `Domain/<Context>/DTOs/`)
+- Value Objects — в `Domain/<Context>/ValueObjects/` или `Domain/Shared/ValueObjects/`
 - Провайдеры регистрируют биндинги интерфейс → реализация
 
-Пример правильного сервиса:
+Пример Action-класса:
 
 ```php
 <?php
 
 declare(strict_types=1);
 
-namespace App\Services\Matching;
+namespace App\Domain\Matching\Actions;
 
-use App\Services\Matching\MatchingEngineInterface;
+use App\Domain\GitLab\Models\Branch;
+use App\Domain\Matching\Enums\ConfidenceLevel;
+use App\Domain\Matching\Events\BranchMatched;
+use App\Domain\Matching\Models\MatchResult;
 
-final class MatchingEngine implements MatchingEngineInterface
+final readonly class MatchBranch
 {
-    public function match(Branch $branch): MatchResult
+    public function __invoke(Branch $branch): MatchResult
     {
-        // ...
+        [$task, $confidence] = $this->resolve($branch);
+
+        $matchResult = $this->createOrUpdateMatch($branch, $task, $confidence);
+
+        BranchMatched::dispatch($matchResult, $branch);
+
+        return $matchResult;
     }
+
+    // ...
+}
+```
+
+Пример инфраструктурного клиента:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Bitrix24;
+
+use App\Domain\Bitrix24\Services\Bitrix24ClientInterface;
+
+final class Bitrix24Client implements Bitrix24ClientInterface
+{
+    // ...
 }
 ```
 
@@ -85,7 +116,7 @@ ESLint-конфиг — `frontend/eslint.config.js`. Правила:
 
 - TypeScript strict mode, нет `any`
 - Функциональные компоненты с хуками, без классов
-- API-клиенты — в `frontend/src/api/`, каждый модуль по домену (sync, reports, inbox, mappings, settings)
+- API-клиенты — в `frontend/src/api/`, каждый модуль по домену (`sync`, `reports`, `inbox`, `settings`)
 - Хуки — в `frontend/src/hooks/`, оборачивают TanStack Query (`useQuery` / `useMutation`)
 - Типы API — в `frontend/src/types/api.ts`
 
@@ -95,6 +126,8 @@ Backend-тесты расположены в `backend/tests/`. Тесты исп
 
 При добавлении нового функционала — писать и unit-, и feature-тесты. Моки внешних сервисов (GitLab, Bitrix24, LLM) обязательны: тесты не должны делать реальных HTTP-запросов.
 
+Раскладка тестов отражает DDD-структуру: `tests/Unit/Domain/<Context>/Actions/`, `tests/Unit/Domain/<Context>/Models/`, `tests/Unit/Domain/<Context>/Queries/`, `tests/Unit/Domain/<Context>/ValueObjects/`. Feature-тесты — в `tests/Feature/<Area>/`.
+
 Паттерн feature-теста:
 
 ```php
@@ -102,31 +135,36 @@ Backend-тесты расположены в `backend/tests/`. Тесты исп
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Services\Narrative;
+namespace Tests\Feature\Report;
 
-use App\Services\LLM\LlmProviderInterface;
+use App\Domain\Narrative\Actions\GenerateNarrativesForReport;
+use App\Domain\Narrative\Services\LlmProviderInterface;
+use App\Domain\Report\Models\Report;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Mocks\MockLlmProvider;
 use Tests\TestCase;
 
-final class NarrativeServiceTest extends TestCase
+final class GenerateNarrativesForReportTest extends TestCase
 {
-    public function test_generates_narrative_for_matched_commits(): void
+    use RefreshDatabase;
+
+    public function test_generates_narratives_for_report(): void
     {
-        // GIVEN: мок LLM-провайдера и набор сопоставленных коммитов
+        // GIVEN: мок LLM-провайдера и отчёт со связанными задачами
         $this->app->bind(LlmProviderInterface::class, MockLlmProvider::class);
-        $task = TaskFactory::new()->withCommits(3)->create();
+        $report = Report::factory()->withTasks(3)->create();
 
-        // WHEN: запускаем генерацию нарратива
-        $result = $this->app->make(NarrativeService::class)->generate($task);
+        // WHEN: запускаем генерацию нарративов через Action
+        $action = $this->app->make(GenerateNarrativesForReport::class);
+        $action($report);
 
-        // THEN: получен текстовый нарратив без ошибок
-        $this->assertNotEmpty($result->text);
-        $this->assertDatabaseHas('narratives', ['task_id' => $task->id]);
+        // THEN: нарративы записаны в историю
+        $this->assertDatabaseCount('narrative_history', 3);
     }
 }
 ```
 
-Ключевые правила: структура GIVEN-WHEN-THEN в комментариях, `final class`, мок внешних сервисов через контейнер, фабрики для тестовых данных, фикстуры JSON для ответов внешних API — в `backend/tests/Fixtures/`.
+Ключевые правила: структура GIVEN-WHEN-THEN в комментариях, `final class`, мок внешних сервисов через контейнер (LLM — через `MockLlmProvider`), фабрики для тестовых данных, фикстуры JSON для ответов внешних API — в `backend/tests/Fixtures/`.
 
 Перед коммитом убедись, что проходят все проверки:
 
@@ -147,28 +185,42 @@ make lint && make test
 
 Основной поток данных при генерации отчёта:
 
-1. **Синхронизация** — `RunSyncJob` (очередь Redis) запускает `SyncService`, который параллельно забирает коммиты из GitLab API и задачи из Bitrix24 REST API, сохраняет в SQLite
-2. **Сопоставление** — `MatchingEngine` связывает коммиты с задачами по имени ветки и conventional commit-сообщениям. Несопоставленные коммиты попадают в Inbox
-3. **Нарратив** — `NarrativeService` отправляет сгруппированные коммиты в LLM (`LlmManager` → `ClaudeProvider` / `OpenAiProvider`) и получает человекочитаемые описания работы
-4. **Сборка отчёта** — `ReportBuilder` компонует данные (задачи + коммиты + нарративы) в структуру отчёта
-5. **Экспорт** — `WordExporter` (PHPWord) генерирует финальный `.docx`-файл
+1. **Синхронизация** — `RunSyncJob` (очередь Redis) выполняет actions `Domain/Sync/Actions/SyncGitLab` и `SyncBitrix24` (с подэтапами `SyncBitrix24Tasks`, `SyncBitrix24TimeEntries`), которые через клиенты `Infrastructure/GitLab/GitLabClient` и `Infrastructure/Bitrix24/Bitrix24Client` забирают данные и сохраняют в SQLite. По завершении — событие `SyncCompleted`.
+2. **Сопоставление** — слушатель `MatchBranchesOnSyncCompleted` запускает actions `Domain/Matching/Actions/MatchBranch` (по одному) или `MatchAllUnmatched` (массово). Имя ветки парсится `Domain/GitLab/Services/BranchParser`, по номеру задачи находится `Bitrix24\Models\Task`, уровень уверенности — enum `ConfidenceLevel`. Несопоставленные коммиты попадают в Inbox (`Domain/Inbox/Queries/GetUnlinkedBranches`).
+3. **Сборка отчёта** — action `Domain/Report/Actions/GenerateReport` компонует данные (задачи + коммиты + временные записи) в структуру отчёта и эмитит событие `ReportGenerated`.
+4. **Нарратив** — слушатель `GenerateNarrativesOnReportGenerated` запускает action `Domain/Narrative/Actions/GenerateNarrativesForReport`, который через `LlmProviderInterface` (реализации в `Infrastructure/LLM/` — `LlmManager` выбирает `ClaudeProvider` / `OpenAiProvider`) получает человекочитаемые описания. Поддерживается ручное редактирование (`EditDayNarrative`, `EditTaskNarrative`) и регенерация (`Regenerate*Narrative`) с записью в `NarrativeHistory`.
+5. **Экспорт** — `Infrastructure/Report/WordExporter` (реализация `Domain/Report/Services/ReportExporterInterface`, PHPWord) генерирует финальный `.docx`-файл. Пустые дни обрабатываются методом `addEmptyDayCell()`, источник дня помечается enum `ReportDaySource`.
 
 Пользователь управляет процессом через React-фронтенд: запускает синхронизацию, проверяет сопоставления в Inbox, корректирует связи, генерирует и скачивает отчёт.
 
-### Сервисный слой
+### Доменный и инфраструктурный слои
 
-Сервисный слой организован по доменам в `backend/app/Services/`:
+Backend организован по DDD-принципу: бизнес-логика — в `backend/app/Domain/<Context>/`, адаптеры к внешним системам — в `backend/app/Infrastructure/<Context>/`.
 
-- `GitLab/` — клиент GitLab API, парсер веток
-- `Bitrix24/` — клиент Bitrix24 REST API
-- `LLM/` — Strategy-паттерн: `LlmManager` выбирает провайдера (`ClaudeProvider` / `OpenAiProvider`) через `LlmProviderInterface`
-- `Matching/` — движок сопоставления коммитов с задачами
-- `Narrative/` — генерация нарративных описаний через LLM
-- `Report/` — сборка отчёта (`ReportBuilder`), экспорт в Word (`WordExporter`), экспорт промпта
-- `Sync/` — оркестрация синхронизации данных, парсер conventional commits
-- `Inbox/` — управление нераспределёнными коммитами
+**`backend/app/Domain/`** — 9 ограниченных контекстов, у каждого своя структура (`Actions/`, `DTOs/`, `Enums/`, `Events/`, `Listeners/`, `Models/`, `Queries/`, `Services/` (контракты), `ValueObjects/` — выборочно):
 
-Фоновая синхронизация выполняется через `RunSyncJob` (Laravel Queue, Redis).
+- `GitLab/` — модели `Branch`, `Commit`; парсеры `BranchParser`, `ConventionalCommitParser`; контракт `GitLabClientInterface`; DTO `ParsedBranch`
+- `Bitrix24/` — модели `Task`, `TimeEntry`; контракт `Bitrix24ClientInterface`; enum-ы `TaskStatus`, `ParticipationRole`
+- `Matching/` — actions `MatchBranch`, `MatchAllUnmatched`, `RematchBranch`; модель `MatchResult`; enum `ConfidenceLevel`; событие `BranchMatched` + слушатель `MatchBranchesOnSyncCompleted`
+- `Narrative/` — actions `GenerateNarrativesForReport`, `EditDay/TaskNarrative`, `RegenerateDay/TaskNarrative`, `UndoDay/TaskNarrative`; модель `NarrativeHistory`; контракт `LlmProviderInterface`; служебный `NarrativeSupport`
+- `Report/` — action `GenerateReport`; модели `Report`, `ReportDay`, `ReportTask`, `ReportDayTask`; queries `GetReportPreview`, `GetMonthlyReportData`, `GetTaskTimeBreakdown` и др.; контракты `ReportExporterInterface`, `PromptExportServiceInterface`; enum-ы `ReportType`, `ReportStatus`, `ReportDaySource`; ValueObject `Narrative`
+- `Sync/` — actions `SyncGitLab`, `SyncBitrix24` (+ `SyncBitrix24Tasks`, `SyncBitrix24TimeEntries`, `SyncBitrix24ForReport`, `EnsureTasksForPeriod`); модели `SyncJob`, `SyncLog`; событие `SyncCompleted`
+- `Inbox/` — actions `AssignBranch`, `BulkAssignBranches`, `CreateTaskAndAssign`, `IgnoreBranch`; query `GetUnlinkedBranches`
+- `Settings/` — модель `Setting`
+- `Shared/` — переиспользуемые ValueObjects `DateRange`, `TaskNumber`
+
+**`backend/app/Infrastructure/`** — реализации контрактов из доменов и адаптеры к внешним API:
+
+- `Bitrix24/Bitrix24Client.php` — реализация `Domain\Bitrix24\Services\Bitrix24ClientInterface`
+- `GitLab/GitLabClient.php` — реализация `Domain\GitLab\Services\GitLabClientInterface`
+- `LLM/` — `LlmManager` (диспетчер провайдеров), `ClaudeProvider`, `OpenAiProvider` (все реализуют `Domain\Narrative\Services\LlmProviderInterface`)
+- `Report/` — `WordExporter`, `PromptExportService` (реализации одноимённых интерфейсов из `Domain/Report/Services/`)
+
+**`backend/app/Models/`** — только `User.php`. Все доменные модели лежат в `Domain/<Context>/Models/`.
+
+**`backend/app/Http/Controllers/`** — тонкий слой (`InboxController`, `ReportController`, `SettingsController`, `SyncController`): принять запрос → вызвать Action/Query → вернуть API Resource.
+
+Фоновая синхронизация выполняется через `App\Jobs\RunSyncJob` (Laravel Queue, Redis).
 
 ## Границы
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,12 @@ git checkout -b feature/my-feature
 
 ### Backend (PHP)
 
-- PHP 8.2+, строгая типизация (`declare(strict_types=1)`)
+- PHP 8.2+, Laravel 12, строгая типизация (`declare(strict_types=1)`)
+- Архитектура — DDD: бизнес-логика в `backend/app/Domain/<Context>/`, адаптеры к внешним системам в `backend/app/Infrastructure/<Context>/` (см. [AGENTS.md](AGENTS.md))
+- Use Cases — `final readonly` Action-классы в `Domain/<Context>/Actions/` с одним публичным методом `__invoke()`
+- Внешние клиенты реализуют интерфейс из `Domain/<Context>/Services/` (например, `Bitrix24ClientInterface` → `Infrastructure/Bitrix24/Bitrix24Client`)
 - Стиль кода — PSR-12, проверяется через [Laravel Pint](https://laravel.com/docs/pint)
 - Статический анализ — PHPStan level 10 + Larastan
-- Каждый сервис имеет интерфейс
 - Английский язык в коде и комментариях
 
 ### Frontend (TypeScript)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
 ```bash
 git clone https://github.com/your-username/report-generator.git
 cd report-generator
-45```
+```
+
 2. **Скопируйте файлы окружения и заполните секреты:**
 
 ```bash
@@ -35,7 +36,7 @@ cp backend/.env.example backend/.env
 
 Отредактируйте `backend/.env` — укажите токены GitLab, Bitrix24 и LLM-провайдера (см. раздел «Конфигурация»).
 
-2. **Запустите проект:**
+3. **Запустите проект:**
 
 ```bash
 make build
@@ -43,7 +44,7 @@ make up
 make migrate
 ```
 
-3. **Откройте в браузере:**
+4. **Откройте в браузере:**
 
 - Frontend: [http://localhost:5173](http://localhost:5173)
 - Backend API: [http://localhost:8000](http://localhost:8000)
@@ -94,13 +95,15 @@ make logs        # Логи контейнеров
 
 ## Стек технологий
 
-- **Backend:** PHP 8.2+ / Laravel 11
-- **Frontend:** React (TypeScript) / Vite
+- **Backend:** PHP 8.2+ / Laravel 12 (DDD: `app/Domain/` + `app/Infrastructure/`)
+- **Frontend:** React 18 (TypeScript) / Vite
 - **БД:** SQLite
 - **Очереди:** Redis + Laravel Queue
 - **Генерация Word:** PHPWord
 - **LLM:** Anthropic Claude API / OpenAI API
 - **Контейнеризация:** Docker Compose
+
+Подробнее о структуре кода — в [AGENTS.md](AGENTS.md) (раздел «Доменный и инфраструктурный слои»). Backend-специфика — в [backend/README.md](backend/README.md), frontend-специфика — в [frontend/README.md](frontend/README.md).
 
 ## Участие в разработке
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,59 +1,69 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Backend — Report Generator
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+Backend Laravel-приложения Report Generator. Бизнес-логика организована по DDD: `Domain/` (контексты) + `Infrastructure/` (адаптеры внешних сервисов).
 
-## About Laravel
+Полный разбор архитектуры — в корневом [AGENTS.md](../AGENTS.md). Установка и запуск окружения — в корневом [README.md](../README.md).
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+## Стек
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+- PHP `^8.2`, расширение `ext-redis`
+- Laravel `^12.0`, `laravel/tinker` `^2.10.1`
+- PHPWord `^1.4` (генерация `.docx`)
+- PHPUnit `^11.5.50` (тесты на in-memory SQLite)
+- Larastan `^3.9` (PHPStan level 10), Laravel Pint `^1.29`
+- Mockery `^1.6`, FakerPHP `^1.23`, Collision `^8.6`, Pail `^1.2.2`, Sail `^1.41`
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+Версии — из [composer.json](composer.json).
 
-## Learning Laravel
+## Структура `app/`
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework. You can also check out [Laravel Learn](https://laravel.com/learn), where you will be guided through building a modern Laravel application.
+```
+app/
+├── Domain/<Context>/{Actions, DTOs, Enums, Events, Listeners, Models, Queries, Services, ValueObjects}
+├── Infrastructure/{Bitrix24, GitLab, LLM, Report}
+├── Http/Controllers/
+├── Jobs/
+├── Console/Commands/
+└── Models/User.php
+```
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+**Контексты (`Domain/`):** `Bitrix24`, `GitLab`, `Inbox`, `Matching`, `Narrative`, `Report`, `Settings`, `Shared`, `Sync`. Подпапки внутри контекста создаются по необходимости — не каждый контекст содержит все девять.
 
-## Laravel Sponsors
+**Инфраструктура (`Infrastructure/`):**
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+- `Bitrix24/Bitrix24Client` — HTTP-клиент Битрикс24
+- `GitLab/GitLabClient` — HTTP-клиент GitLab
+- `LLM/{LlmManager, ClaudeProvider, OpenAiProvider}` — провайдеры LLM
+- `Report/{WordExporter, PromptExportService}` — экспорт `.docx` и выгрузка промптов
 
-### Premium Partners
+`App\Models\User` намеренно остаётся в `app/Models/` (требование Laravel auth). Доменные модели живут в `Domain/<Context>/Models/`.
 
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
+Подробное описание границ контекстов, потоков данных и принятых паттернов — в [AGENTS.md](../AGENTS.md).
 
-## Contributing
+## Запуск
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+Установка, поднятие docker-окружения и фронтенда — через корневой [Makefile](../Makefile). См. корневой [README.md](../README.md).
 
-## Code of Conduct
+Команды, специфичные для backend:
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+- `make migrate` — применить миграции
+- `make test` — PHPUnit (in-memory SQLite)
+- `make lint` — Pint + PHPStan (level 10)
+- `make fix` — автоисправления Pint
+- Запуск конкретного теста: `docker exec moronocracy-backend php artisan test --filter=ИмяТеста`
 
-## Security Vulnerabilities
+## Тестирование
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+- `tests/Unit/Domain/<Context>/...` — зеркало DDD-структуры; покрывает Actions, Services, ValueObjects, Queries
+- `tests/Feature/...` — HTTP/интеграционные тесты контроллеров и джобов
+- In-memory SQLite (см. `phpunit.xml`)
+- `tests/Mocks/MockLlmProvider.php` — детерминированный мок LLM
+- `tests/Fixtures/` — фикстуры запросов/ответов внешних API
 
-## License
+Примеры тестов и принятые соглашения — в [AGENTS.md](../AGENTS.md).
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+## См. также
+
+- [AGENTS.md](../AGENTS.md) — архитектура, контексты, паттерны, тестирование
+- [README.md](../README.md) — установка, запуск, команды Makefile
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — процесс контрибьюшна

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,50 +1,67 @@
-# React + TypeScript + Vite
+# Frontend — Report Generator
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React SPA для генерации отчётов разработчика. Обращается к backend (Laravel 12) через REST API, получает статус синхронизации через Server-Sent Events.
 
-Currently, two official plugins are available:
+Главный документ проекта — [../AGENTS.md](../AGENTS.md). Здесь — только то, что специфично для `frontend/`.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Стек
 
-## Expanding the ESLint configuration
+Версии зафиксированы в [`package.json`](package.json).
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
+| Технология | Версия |
+| --- | --- |
+| React | 18.3 |
+| TypeScript | 5.6 |
+| Vite | 5.4 |
+| React Router DOM | 7.13 |
+| TanStack Query | 5.90 |
+| ESLint | 9.13 (`typescript-eslint` 8.11) |
+| Prettier | конфиг общий с проектом |
 
-- Configure the top-level `parserOptions` property like this:
+## Структура `src/`
 
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```
+src/
+  api/          модули по доменам — по одному файлу на ресурс
+  hooks/        обёртки над TanStack Query
+  pages/        точки входа маршрутов
+  components/   переиспользуемые блоки, сгруппированные по доменам
+  types/        TypeScript-типы запросов и ответов API
+  utils/        вспомогательные функции
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+- **`api/`** — `client.ts` обёртка над `fetch` (базовый URL, заголовки, обработка ошибок); `sync.ts`, `reports.ts`, `inbox.ts`, `settings.ts` — по одному файлу на ресурс backend.
+- **`hooks/`** — `useReports`, `useInbox`, `useSync` поверх `useQuery` / `useMutation`; `useSyncSSE` — Server-Sent Events для статуса синхронизации в реальном времени.
+- **`pages/`** — `DashboardPage`, `InboxPage`, `ReportPage`, `SettingsPage`. Маршруты подключаются в `App.tsx`.
+- **`components/`** — подпапки по доменам: `inbox/`, `report/`, `sync/`, `layout/` (`AppLayout` — общий каркас страниц).
+- **`types/`** — `api.ts` с типами DTO, общими для нескольких модулей.
+- **`utils/`** — `formatDuration`, `taskTitle` и прочие чистые функции.
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
+## Запуск
 
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+Установка и запуск выполняются через корневой `Makefile`, см. [../README.md](../README.md). Frontend поднимается контейнером `node` командой `make up` и слушает `http://localhost:5173`. Vite проксирует API-запросы на backend (`http://localhost:8000`).
+
+Локальные команды (npm-скрипты в `package.json`) выполняются внутри контейнера `node`. Точные команды `docker compose exec node …` см. в корневом [AGENTS.md](../AGENTS.md).
+
+## Стиль кода
+
+- TypeScript strict mode (`tsconfig.app.json`).
+- ESLint — конфиг [`eslint.config.js`](eslint.config.js): `typescript-eslint`, `react-hooks`, `react-refresh`.
+- Prettier — общие настройки проекта.
+- Только функциональные компоненты и хуки, без классов.
+- `any` запрещён; неизвестные данные типизируем через `unknown` и сужаем.
+
+Проверки и автоисправление запускаются из корня для всего репозитория:
+
+```bash
+make lint   # backend + frontend (Pint, PHPStan, ESLint, Prettier)
+make fix    # автоисправление (Pint + Prettier)
 ```
+
+Подробнее о правилах и архитектуре — [../AGENTS.md](../AGENTS.md).
+
+## См. также
+
+- [../AGENTS.md](../AGENTS.md) — главный документ: стек, команды, архитектура, правила code review.
+- [../README.md](../README.md) — пользовательская часть README.
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — процесс контрибьюции.


### PR DESCRIPTION
Reflect the post-DDD refactor (issue #1, ProjectMapping removal in 782196c) across all public markdown docs. Replace flat App\Services\* references with Domain/<Context> + Infrastructure/<Context> layout, swap removed classes (MatchingEngine, NarrativeGenerator, ReportBuilder, ReportExporter, EmptyDayHandler) for actual actions/managers, and bump Laravel 11 -> 12. Replace default Laravel and Vite README templates in backend/ and frontend/ with project-specific content. Fix typo and broken numbering in the root README.

Closes #31 