### PR TITLE
ci: setup Dependabot version updates for composer, npm, github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,117 @@
+# Dependabot version updates.
+# Документация: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Все коммиты идут с префиксом "deps:" — он есть в нашем commitlint enum
+# и маппится в секцию "Changed" CHANGELOG.md (см. release-please-config.json).
+version: 2
+
+updates:
+  # ─── Backend (PHP / Composer) ─────────────────────────────────
+  - package-ecosystem: "composer"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Moscow"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      laravel:
+        patterns:
+          - "laravel/*"
+          - "illuminate/*"
+      php-testing:
+        patterns:
+          - "phpunit/*"
+          - "mockery/*"
+          - "fakerphp/*"
+          - "larastan/*"
+          - "nunomaduro/collision"
+      dev-deps:
+        dependency-type: "development"
+        exclude-patterns:
+          - "phpunit/*"
+          - "mockery/*"
+          - "fakerphp/*"
+          - "larastan/*"
+
+  # ─── Frontend (NPM) ───────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Moscow"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@vitejs/plugin-react"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "eslint-plugin-*"
+          - "typescript-eslint"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      types:
+        patterns:
+          - "@types/*"
+        exclude-patterns:
+          - "@types/react"
+          - "@types/react-dom"
+
+  # ─── Root tooling (NPM: lefthook + commitlint) ────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Moscow"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "tooling"
+    commit-message:
+      prefix: "deps"
+    groups:
+      commitlint:
+        patterns:
+          - "@commitlint/*"
+
+  # ─── GitHub Actions ───────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Moscow"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,26 @@ make test   # запуск тестов
 
 PR-ветки мерджатся через **squash & merge**: каждая ветка → один коммит на `master`. Это держит историю плоской и release-please видит чистый поток conventional commits.
 
+## Управление зависимостями
+
+Зависимости обновляет [Dependabot](https://docs.github.com/en/code-security/dependabot) — built-in в GitHub. Конфиг в [`.github/dependabot.yml`](.github/dependabot.yml).
+
+**Два независимых механизма:**
+
+1. **Security updates** — открываются автоматически при появлении CVE в зависимостях.
+2. **Version updates** — еженедельные обновления зависимостей до последних версий. Конфигурируются в `dependabot.yml`.
+
+**Что мониторится:**
+
+- `composer` в `/backend` — еженедельно
+- `npm` в `/frontend` — еженедельно
+- `npm` в `/` (root tooling: lefthook + commitlint) — раз в месяц
+- `github-actions` в `/` — раз в месяц
+
+**Группы пакетов** (один PR на группу вместо одного на пакет): laravel + illuminate, react-stack, eslint-stack, php-testing, dev-deps.
+
+**Conventional Commits:** Dependabot коммитит как `deps(scope): bump foo from 1.2.0 to 1.2.3` — попадает в нашу `commitlint`-схему (`deps:` тип в enum) и release-please мапит в секцию `Changed` CHANGELOG'а.
+
 ## Релизы
 
 Релизами управляет [release-please](https://github.com/googleapis/release-please) автоматически:


### PR DESCRIPTION
Configures version updates for /backend (composer), /frontend (npm), / (root tooling npm), and / (github-actions). Groups related packages (laravel, react, eslint, php-testing) into single PRs. Uses 'deps:' commit prefix to align with commitlint enum and release-please mapping.

Closes #46

## Чеклист

- [ ] Имя ветки соответствует Conventional Branch (`<type>/<slug>` или `<type>/<issue#>-<slug>`)
- [ ] Заголовок PR — в формате Conventional Commits
- [ ] `make lint` и `make test` проходят локально
- [ ] Документация обновлена (если затрагивает поведение, видимое пользователю)
- [ ] Один логический change в PR (не смешано несколько задач)
