### PR TITLE
Refactor/react hooks v7 comply

### DIFF
--- a/frontend/src/components/settings/SettingsForm.tsx
+++ b/frontend/src/components/settings/SettingsForm.tsx
@@ -1,0 +1,371 @@
+import { useState } from "react";
+import type { Settings, SettingsInput } from "../../types/api";
+
+interface SettingsFormProps {
+  initial: Settings;
+  onSubmit: (payload: SettingsInput) => void;
+  isSubmitting: boolean;
+  saveMessage: string | null;
+}
+
+function buildInitialForm(settings: Settings): SettingsInput {
+  return {
+    gitlab_username: settings.gitlab_username ?? "",
+    gitlab_email: settings.gitlab_email ?? "",
+    bitrix24_user_id: settings.bitrix24_user_id ?? "",
+    llm_provider: settings.llm_provider,
+    llm_system_prompt: settings.llm_system_prompt ?? "",
+    enriched_prompt_enabled: settings.enriched_prompt_enabled,
+    developer_name: settings.developer_name ?? "",
+    developer_position: settings.developer_position ?? "",
+    sync_schedule_time: settings.sync_schedule_time,
+  };
+}
+
+export function SettingsForm({
+  initial,
+  onSubmit,
+  isSubmitting,
+  saveMessage,
+}: SettingsFormProps) {
+  const [form, setForm] = useState<SettingsInput>(() =>
+    buildInitialForm(initial),
+  );
+
+  const handleChange = (field: keyof SettingsInput, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Only send non-empty password fields
+    const payload: SettingsInput = { ...form };
+    if (!payload.gitlab_token) delete payload.gitlab_token;
+    if (!payload.bitrix24_api_key) delete payload.bitrix24_api_key;
+    if (!payload.llm_api_key) delete payload.llm_api_key;
+    onSubmit(payload);
+  };
+
+  const labelStyle: React.CSSProperties = {
+    display: "block",
+    marginBottom: "8px",
+    fontSize: "15px",
+    fontWeight: 700,
+    color: "#afafb3",
+    letterSpacing: "0.02em",
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "10px 12px",
+    border: "1px solid #444",
+    borderRadius: "6px",
+    boxSizing: "border-box",
+    background: "#2a2a3a",
+    color: "rgba(255, 255, 255, 0.87)",
+    fontSize: "14px",
+  };
+
+  const fieldStyle: React.CSSProperties = {
+    marginBottom: "20px",
+  };
+
+  const statusText = (configured: boolean) =>
+    configured ? "[Настроен]" : "[Не настроен]";
+
+  const statusColor = (configured: boolean) =>
+    configured ? "#38a169" : "#e53e3e";
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        maxWidth: "600px",
+        background: "#1e1e2e",
+        padding: "24px",
+        borderRadius: "8px",
+        border: "1px solid #333",
+      }}
+    >
+      <div style={fieldStyle}>
+        <label style={labelStyle}>
+          GitLab Token{" "}
+          <span
+            style={{
+              color: statusColor(initial.has_gitlab_token),
+              fontWeight: "normal",
+            }}
+          >
+            {statusText(initial.has_gitlab_token)}
+          </span>
+        </label>
+        <input
+          type="password"
+          placeholder="Введите новый токен для обновления"
+          value={form.gitlab_token ?? ""}
+          onChange={(e) => handleChange("gitlab_token", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>GitLab Username</label>
+        <input
+          type="text"
+          value={form.gitlab_username ?? ""}
+          onChange={(e) => handleChange("gitlab_username", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>
+          GitLab Email
+          <span
+            style={{
+              fontSize: "12px",
+              fontWeight: "normal",
+              color: "rgba(255, 255, 255, 0.5)",
+              marginLeft: "8px",
+            }}
+          >
+            Для фильтрации коммитов по автору
+          </span>
+        </label>
+        <input
+          type="email"
+          placeholder="user@example.com"
+          value={form.gitlab_email ?? ""}
+          onChange={(e) => handleChange("gitlab_email", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>
+          Bitrix24 API Key{" "}
+          <span
+            style={{
+              color: statusColor(initial.has_bitrix24_api_key),
+              fontWeight: "normal",
+            }}
+          >
+            {statusText(initial.has_bitrix24_api_key)}
+          </span>
+        </label>
+        <input
+          type="password"
+          placeholder="Введите новый ключ для обновления"
+          value={form.bitrix24_api_key ?? ""}
+          onChange={(e) => handleChange("bitrix24_api_key", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>Bitrix24 User ID</label>
+        <input
+          type="text"
+          value={form.bitrix24_user_id ?? ""}
+          onChange={(e) => handleChange("bitrix24_user_id", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>LLM Provider</label>
+        <select
+          value={form.llm_provider ?? "claude"}
+          onChange={(e) => handleChange("llm_provider", e.target.value)}
+          style={inputStyle}
+        >
+          <option value="claude">Claude</option>
+          <option value="openai">OpenAI</option>
+        </select>
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>
+          LLM API Key{" "}
+          <span
+            style={{
+              color: statusColor(initial.has_llm_api_key),
+              fontWeight: "normal",
+            }}
+          >
+            {statusText(initial.has_llm_api_key)}
+          </span>
+        </label>
+        <input
+          type="password"
+          placeholder="Введите новый ключ для обновления"
+          value={form.llm_api_key ?? ""}
+          onChange={(e) => handleChange("llm_api_key", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>Системный промпт LLM</label>
+        <textarea
+          value={form.llm_system_prompt ?? ""}
+          onChange={(e) => handleChange("llm_system_prompt", e.target.value)}
+          rows={5}
+          placeholder="Опишите тон, стиль и уровень детализации нарративов"
+          style={{
+            ...inputStyle,
+            fontFamily: "inherit",
+            resize: "vertical",
+          }}
+        />
+        <div
+          style={{
+            marginTop: "4px",
+            fontSize: "12px",
+            color: "rgba(255, 255, 255, 0.5)",
+            display: "flex",
+            justifyContent: "space-between",
+          }}
+        >
+          <span>
+            Настройте тон, стиль и уровень детализации нарративов под требования
+            вашего руководителя.
+          </span>
+          <button
+            type="button"
+            onClick={() => handleChange("llm_system_prompt", "")}
+            style={{
+              background: "none",
+              border: "none",
+              color: "#646cff",
+              cursor: "pointer",
+              fontSize: "12px",
+              padding: 0,
+              textDecoration: "underline",
+            }}
+          >
+            Сбросить по умолчанию
+          </button>
+        </div>
+      </div>
+
+      <div style={fieldStyle}>
+        <label
+          style={{
+            ...labelStyle,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            cursor: "pointer",
+          }}
+        >
+          <div>
+            <span>Обогащённый контекст для LLM</span>
+            <div
+              style={{
+                fontSize: "12px",
+                fontWeight: "normal",
+                color: "rgba(255, 255, 255, 0.5)",
+                marginTop: "4px",
+              }}
+            >
+              Добавляет описание MR, статистику изменений и список файлов в
+              промпт
+            </div>
+          </div>
+          <div
+            onClick={() =>
+              setForm((prev) => ({
+                ...prev,
+                enriched_prompt_enabled: !prev.enriched_prompt_enabled,
+              }))
+            }
+            style={{
+              width: "44px",
+              height: "24px",
+              borderRadius: "12px",
+              background: form.enriched_prompt_enabled ? "#646cff" : "#444",
+              position: "relative",
+              transition: "background 0.2s",
+              cursor: "pointer",
+              flexShrink: 0,
+              marginLeft: "16px",
+            }}
+          >
+            <div
+              style={{
+                width: "20px",
+                height: "20px",
+                borderRadius: "50%",
+                background: "#fff",
+                position: "absolute",
+                top: "2px",
+                left: form.enriched_prompt_enabled ? "22px" : "2px",
+                transition: "left 0.2s",
+              }}
+            />
+          </div>
+        </label>
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>Имя разработчика</label>
+        <input
+          type="text"
+          value={form.developer_name ?? ""}
+          onChange={(e) => handleChange("developer_name", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>Должность</label>
+        <input
+          type="text"
+          value={form.developer_position ?? ""}
+          onChange={(e) => handleChange("developer_position", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle}>Время синхронизации</label>
+        <input
+          type="time"
+          value={form.sync_schedule_time ?? "09:00"}
+          onChange={(e) => handleChange("sync_schedule_time", e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "12px",
+        }}
+      >
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          style={{
+            padding: "10px 24px",
+            background: isSubmitting ? "#999" : "#646cff",
+            color: "#fff",
+            border: "none",
+            borderRadius: "6px",
+            cursor: isSubmitting ? "not-allowed" : "pointer",
+            fontSize: "15px",
+          }}
+        >
+          {isSubmitting ? "Сохранение..." : "Сохранить"}
+        </button>
+        {saveMessage && (
+          <span style={{ color: "#38a169", fontSize: "14px" }}>
+            {saveMessage}
+          </span>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/hooks/useSyncSSE.ts
+++ b/frontend/src/hooks/useSyncSSE.ts
@@ -14,10 +14,6 @@ export function useSyncSSE() {
   const disconnectedByUserRef = useRef<boolean>(false);
   const retryCountRef = useRef<number>(0);
   const reconnectTimerRef = useRef<number | null>(null);
-  // Holds the latest `connect` implementation so the reconnect timer can call
-  // it recursively without referring to the binding before it is initialised
-  // (which the react-hooks/immutability rule in eslint-plugin-react-hooks v7
-  // flags as a TDZ access).
   const connectRef = useRef<() => void>(() => {});
 
   const connect = useCallback(() => {
@@ -34,11 +30,9 @@ export function useSyncSSE() {
     const handleEvent = (event: MessageEvent) => {
       const data: SyncProgress = JSON.parse(event.data);
       setProgress(data);
-      // reset backoff on any event so transient blips don't exhaust retries
       retryCountRef.current = 0;
 
       if (data.status === "success" || data.status === "failed") {
-        // suppress reconnect after clean server close on terminal status
         disconnectedByUserRef.current = true;
         es.close();
         eventSourceRef.current = null;
@@ -62,8 +56,6 @@ export function useSyncSSE() {
     };
   }, []);
 
-  // Keep the ref in sync with the latest `connect` callback identity so the
-  // recursive reconnect path always uses the current implementation.
   useEffect(() => {
     connectRef.current = connect;
   }, [connect]);

--- a/frontend/src/hooks/useSyncSSE.ts
+++ b/frontend/src/hooks/useSyncSSE.ts
@@ -14,6 +14,11 @@ export function useSyncSSE() {
   const disconnectedByUserRef = useRef<boolean>(false);
   const retryCountRef = useRef<number>(0);
   const reconnectTimerRef = useRef<number | null>(null);
+  // Holds the latest `connect` implementation so the reconnect timer can call
+  // it recursively without referring to the binding before it is initialised
+  // (which the react-hooks/immutability rule in eslint-plugin-react-hooks v7
+  // flags as a TDZ access).
+  const connectRef = useRef<() => void>(() => {});
 
   const connect = useCallback(() => {
     disconnectedByUserRef.current = false;
@@ -52,10 +57,16 @@ export function useSyncSSE() {
       const delay = Math.min(2000 * 2 ** retryCountRef.current, 15000);
       retryCountRef.current += 1;
       reconnectTimerRef.current = window.setTimeout(() => {
-        connect();
+        connectRef.current();
       }, delay);
     };
   }, []);
+
+  // Keep the ref in sync with the latest `connect` callback identity so the
+  // recursive reconnect path always uses the current implementation.
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
 
   const disconnect = useCallback(() => {
     disconnectedByUserRef.current = true;

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { settingsApi } from "../api/settings";
+import { SettingsForm } from "../components/settings/SettingsForm";
 import type { SettingsInput } from "../types/api";
 
 export function SettingsPage() {
@@ -10,374 +11,35 @@ export function SettingsPage() {
     queryFn: settingsApi.get,
   });
 
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const saveMessageTimerRef = useRef<number | null>(null);
+
   const updateSettings = useMutation({
     mutationFn: (data: SettingsInput) => settingsApi.update(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["settings"] });
       setSaveMessage("Настройки сохранены");
-      setTimeout(() => setSaveMessage(null), 3000);
+      if (saveMessageTimerRef.current) {
+        clearTimeout(saveMessageTimerRef.current);
+      }
+      saveMessageTimerRef.current = window.setTimeout(
+        () => setSaveMessage(null),
+        3000,
+      );
     },
   });
 
-  const [form, setForm] = useState<SettingsInput>({});
-  const [saveMessage, setSaveMessage] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (settings) {
-      setForm({
-        gitlab_username: settings.gitlab_username ?? "",
-        gitlab_email: settings.gitlab_email ?? "",
-        bitrix24_user_id: settings.bitrix24_user_id ?? "",
-        llm_provider: settings.llm_provider,
-        llm_system_prompt: settings.llm_system_prompt ?? "",
-        enriched_prompt_enabled: settings.enriched_prompt_enabled,
-        developer_name: settings.developer_name ?? "",
-        developer_position: settings.developer_position ?? "",
-        sync_schedule_time: settings.sync_schedule_time,
-      });
-    }
-  }, [settings]);
-
-  const handleChange = (field: keyof SettingsInput, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    // Only send non-empty password fields
-    const payload: SettingsInput = { ...form };
-    if (!payload.gitlab_token) delete payload.gitlab_token;
-    if (!payload.bitrix24_api_key) delete payload.bitrix24_api_key;
-    if (!payload.llm_api_key) delete payload.llm_api_key;
-    updateSettings.mutate(payload);
-  };
-
-  if (isLoading) return <div>Загрузка...</div>;
-
-  const labelStyle: React.CSSProperties = {
-    display: "block",
-    marginBottom: "8px",
-    fontSize: "15px",
-    fontWeight: 700,
-    color: "#afafb3",
-    letterSpacing: "0.02em",
-  };
-
-  const inputStyle: React.CSSProperties = {
-    width: "100%",
-    padding: "10px 12px",
-    border: "1px solid #444",
-    borderRadius: "6px",
-    boxSizing: "border-box",
-    background: "#2a2a3a",
-    color: "rgba(255, 255, 255, 0.87)",
-    fontSize: "14px",
-  };
-
-  const fieldStyle: React.CSSProperties = {
-    marginBottom: "20px",
-  };
-
-  const statusText = (configured: boolean) =>
-    configured ? "[Настроен]" : "[Не настроен]";
-
-  const statusColor = (configured: boolean) =>
-    configured ? "#38a169" : "#e53e3e";
+  if (isLoading || !settings) return <div>Загрузка...</div>;
 
   return (
     <div>
       <h1 style={{ marginTop: 0 }}>Настройки</h1>
-
-      <form
-        onSubmit={handleSubmit}
-        style={{
-          maxWidth: "600px",
-          background: "#1e1e2e",
-          padding: "24px",
-          borderRadius: "8px",
-          border: "1px solid #333",
-        }}
-      >
-        <div style={fieldStyle}>
-          <label style={labelStyle}>
-            GitLab Token{" "}
-            <span
-              style={{
-                color: statusColor(settings?.has_gitlab_token ?? false),
-                fontWeight: "normal",
-              }}
-            >
-              {statusText(settings?.has_gitlab_token ?? false)}
-            </span>
-          </label>
-          <input
-            type="password"
-            placeholder="Введите новый токен для обновления"
-            value={form.gitlab_token ?? ""}
-            onChange={(e) => handleChange("gitlab_token", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>GitLab Username</label>
-          <input
-            type="text"
-            value={form.gitlab_username ?? ""}
-            onChange={(e) => handleChange("gitlab_username", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>
-            GitLab Email
-            <span
-              style={{
-                fontSize: "12px",
-                fontWeight: "normal",
-                color: "rgba(255, 255, 255, 0.5)",
-                marginLeft: "8px",
-              }}
-            >
-              Для фильтрации коммитов по автору
-            </span>
-          </label>
-          <input
-            type="email"
-            placeholder="user@example.com"
-            value={form.gitlab_email ?? ""}
-            onChange={(e) => handleChange("gitlab_email", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>
-            Bitrix24 API Key{" "}
-            <span
-              style={{
-                color: statusColor(settings?.has_bitrix24_api_key ?? false),
-                fontWeight: "normal",
-              }}
-            >
-              {statusText(settings?.has_bitrix24_api_key ?? false)}
-            </span>
-          </label>
-          <input
-            type="password"
-            placeholder="Введите новый ключ для обновления"
-            value={form.bitrix24_api_key ?? ""}
-            onChange={(e) => handleChange("bitrix24_api_key", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>Bitrix24 User ID</label>
-          <input
-            type="text"
-            value={form.bitrix24_user_id ?? ""}
-            onChange={(e) => handleChange("bitrix24_user_id", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>LLM Provider</label>
-          <select
-            value={form.llm_provider ?? "claude"}
-            onChange={(e) => handleChange("llm_provider", e.target.value)}
-            style={inputStyle}
-          >
-            <option value="claude">Claude</option>
-            <option value="openai">OpenAI</option>
-          </select>
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>
-            LLM API Key{" "}
-            <span
-              style={{
-                color: statusColor(settings?.has_llm_api_key ?? false),
-                fontWeight: "normal",
-              }}
-            >
-              {statusText(settings?.has_llm_api_key ?? false)}
-            </span>
-          </label>
-          <input
-            type="password"
-            placeholder="Введите новый ключ для обновления"
-            value={form.llm_api_key ?? ""}
-            onChange={(e) => handleChange("llm_api_key", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>Системный промпт LLM</label>
-          <textarea
-            value={form.llm_system_prompt ?? ""}
-            onChange={(e) => handleChange("llm_system_prompt", e.target.value)}
-            rows={5}
-            placeholder="Опишите тон, стиль и уровень детализации нарративов"
-            style={{
-              ...inputStyle,
-              fontFamily: "inherit",
-              resize: "vertical",
-            }}
-          />
-          <div
-            style={{
-              marginTop: "4px",
-              fontSize: "12px",
-              color: "rgba(255, 255, 255, 0.5)",
-              display: "flex",
-              justifyContent: "space-between",
-            }}
-          >
-            <span>
-              Настройте тон, стиль и уровень детализации нарративов под
-              требования вашего руководителя.
-            </span>
-            <button
-              type="button"
-              onClick={() => handleChange("llm_system_prompt", "")}
-              style={{
-                background: "none",
-                border: "none",
-                color: "#646cff",
-                cursor: "pointer",
-                fontSize: "12px",
-                padding: 0,
-                textDecoration: "underline",
-              }}
-            >
-              Сбросить по умолчанию
-            </button>
-          </div>
-        </div>
-
-        <div style={fieldStyle}>
-          <label
-            style={{
-              ...labelStyle,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              cursor: "pointer",
-            }}
-          >
-            <div>
-              <span>Обогащённый контекст для LLM</span>
-              <div
-                style={{
-                  fontSize: "12px",
-                  fontWeight: "normal",
-                  color: "rgba(255, 255, 255, 0.5)",
-                  marginTop: "4px",
-                }}
-              >
-                Добавляет описание MR, статистику изменений и список файлов в
-                промпт
-              </div>
-            </div>
-            <div
-              onClick={() =>
-                setForm((prev) => ({
-                  ...prev,
-                  enriched_prompt_enabled: !prev.enriched_prompt_enabled,
-                }))
-              }
-              style={{
-                width: "44px",
-                height: "24px",
-                borderRadius: "12px",
-                background: form.enriched_prompt_enabled ? "#646cff" : "#444",
-                position: "relative",
-                transition: "background 0.2s",
-                cursor: "pointer",
-                flexShrink: 0,
-                marginLeft: "16px",
-              }}
-            >
-              <div
-                style={{
-                  width: "20px",
-                  height: "20px",
-                  borderRadius: "50%",
-                  background: "#fff",
-                  position: "absolute",
-                  top: "2px",
-                  left: form.enriched_prompt_enabled ? "22px" : "2px",
-                  transition: "left 0.2s",
-                }}
-              />
-            </div>
-          </label>
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>Имя разработчика</label>
-          <input
-            type="text"
-            value={form.developer_name ?? ""}
-            onChange={(e) => handleChange("developer_name", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>Должность</label>
-          <input
-            type="text"
-            value={form.developer_position ?? ""}
-            onChange={(e) => handleChange("developer_position", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>Время синхронизации</label>
-          <input
-            type="time"
-            value={form.sync_schedule_time ?? "09:00"}
-            onChange={(e) => handleChange("sync_schedule_time", e.target.value)}
-            style={inputStyle}
-          />
-        </div>
-
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "12px",
-          }}
-        >
-          <button
-            type="submit"
-            disabled={updateSettings.isPending}
-            style={{
-              padding: "10px 24px",
-              background: updateSettings.isPending ? "#999" : "#646cff",
-              color: "#fff",
-              border: "none",
-              borderRadius: "6px",
-              cursor: updateSettings.isPending ? "not-allowed" : "pointer",
-              fontSize: "15px",
-            }}
-          >
-            {updateSettings.isPending ? "Сохранение..." : "Сохранить"}
-          </button>
-          {saveMessage && (
-            <span style={{ color: "#38a169", fontSize: "14px" }}>
-              {saveMessage}
-            </span>
-          )}
-        </div>
-      </form>
+      <SettingsForm
+        initial={settings}
+        onSubmit={(payload) => updateSettings.mutate(payload)}
+        isSubmitting={updateSettings.isPending}
+        saveMessage={saveMessage}
+      />
     </div>
   );
 }


### PR DESCRIPTION
eslint-plugin-react-hooks 7.x introduced two new rules that flag
legitimate anti-patterns in our existing code. Refactored to comply
without changing observable behavior.

1. react-hooks/immutability in useSyncSSE.ts
   The recursive `connect()` call inside `onerror` was triggering a
   TDZ-aware check (the binding could be referenced before its
   `useCallback` initializer fully completes during React's render).
   Introduced a `connectRef = useRef<() => void>` synced via a
   one-line effect, and the recursive reconnect now goes through
   `connectRef.current()` instead of the closure-captured `connect`.
   All ref-mutation logic, exponential backoff, and terminal-status
   suppression preserved. Public API ({ progress, connect, disconnect })
   unchanged — SyncButton.tsx works without modification.

2. react-hooks/set-state-in-effect in SettingsPage.tsx
   Replaced the `useEffect → setForm` derived-state pattern with a
   component split per React 19 guidelines (you-might-not-need-an-effect):
   - SettingsPage now only loads settings via TanStack Query, owns the
     mutation and saveMessage state, renders a loading placeholder
     until settings are available, then mounts <SettingsForm initial=...>
   - SettingsForm (new component in components/settings/) owns the
     local form state, initialized via useState lazy initializer
     `() => buildInitialForm(initial)`. All field handlers, validation
     and submit logic moved here unchanged.
