### PR TITLE
docs(github): translate templates and tooling configs to English

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,37 +1,37 @@
 name: 🐛 Bug Report
-description: Сообщить о баге
+description: Report a bug
 title: "fix: "
 labels: ["bug"]
 body:
   - type: textarea
     id: what-happened
     attributes:
-      label: Что произошло
-      description: Опишите наблюдаемое поведение.
+      label: What happened
+      description: Describe the observed behavior.
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
-      label: Что ожидалось
-      description: Какое поведение вы ожидали увидеть.
+      label: What you expected
+      description: The behavior you expected to see.
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
-      label: Шаги для воспроизведения
-      description: Пошаговая инструкция.
+      label: Steps to reproduce
+      description: A step-by-step recipe.
       placeholder: |
-        1. Открыть страницу /reports
-        2. Нажать «Сгенерировать»
+        1. Open the /reports page
+        2. Click "Generate"
         3. ...
     validations:
       required: true
   - type: textarea
     id: environment
     attributes:
-      label: Окружение
+      label: Environment
       placeholder: |
         OS:           Windows 11
         PHP:          8.2.12
@@ -42,8 +42,8 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Логи / скриншоты
-      description: Если есть.
+      label: Logs / screenshots
+      description: If available.
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Вопрос или обсуждение
+  - name: 💬 Question or discussion
     url: https://github.com/Meacue/report-generator/discussions
-    about: Для общих вопросов используйте Discussions, не Issues.
+    about: For general questions, please use Discussions, not Issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,37 +1,37 @@
 name: ✨ Feature Request
-description: Предложить новую функциональность
+description: Propose new functionality
 title: "feat: "
 labels: ["enhancement"]
 body:
   - type: textarea
     id: problem
     attributes:
-      label: Какую проблему решает
-      description: Опишите проблему, которую решит фича. Без описания проблемы — фича не нужна.
+      label: Problem this solves
+      description: Describe the problem the feature would solve. Without a problem statement the feature isn't justified.
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
-      label: Предлагаемое решение
-      description: Как вы видите реализацию. Можно высокоуровнево.
+      label: Proposed solution
+      description: How you see the implementation. High-level is fine.
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Альтернативы
-      description: Какие ещё варианты рассматривались и почему отвергнуты.
+      label: Alternatives
+      description: Other options considered and why they were rejected.
     validations:
       required: false
   - type: textarea
     id: acceptance
     attributes:
-      label: Критерии приёмки
-      description: Как мы поймём, что фича готова.
+      label: Acceptance criteria
+      description: How we'll know the feature is done.
       placeholder: |
-        - [ ] Endpoint /api/foo возвращает 200 на валидный запрос
-        - [ ] Покрыт unit-тестом
-        - [ ] Описан в README/AGENTS
+        - [ ] Endpoint /api/foo returns 200 for a valid request
+        - [ ] Covered by a unit test
+        - [ ] Documented in README/AGENTS
     validations:
       required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,31 @@
 <!--
-Заголовок PR должен быть в формате Conventional Commits, например:
+The PR title must follow Conventional Commits, for example:
   feat(bitrix): sanitize PII in comment payload
   fix(report): correct LLM token counter for Russian text
   chore(deps): bump phpoffice/phpword to 1.4.1
 
-Это становится сообщением единственного коммита после squash-merge,
-что напрямую влияет на CHANGELOG.md и SemVer-bump.
+It becomes the message of the single commit produced by squash-merge,
+which directly drives CHANGELOG.md and the SemVer bump.
 -->
 
-## Что меняется
+## What changes
 
-<!-- Кратко: что сделано в этом PR. Один логический change. -->
+<!-- Briefly: what this PR does. One logical change. -->
 
-## Зачем
+## Why
 
-<!-- Какую проблему решает. Ссылка на issue. -->
+<!-- The problem this solves. Link to the issue. -->
 
 Closes #
 
-## Как проверить
+## How to verify
 
-<!-- Шаги для ручной проверки или ссылка на тесты. -->
+<!-- Manual verification steps or a link to tests. -->
 
-## Чеклист
+## Checklist
 
-- [ ] Имя ветки соответствует Conventional Branch (`<type>/<slug>` или `<type>/<issue#>-<slug>`)
-- [ ] Заголовок PR — в формате Conventional Commits
-- [ ] `make lint` и `make test` проходят локально
-- [ ] Документация обновлена (если затрагивает поведение, видимое пользователю)
-- [ ] Один логический change в PR (не смешано несколько задач)
+- [ ] Branch name follows Conventional Branch (`<type>/<slug>` or `<type>/<issue#>-<slug>`)
+- [ ] PR title follows Conventional Commits
+- [ ] `make lint` and `make test` pass locally
+- [ ] Documentation updated (if user-visible behavior is affected)
+- [ ] One logical change in the PR (multiple tasks not mixed)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 # Dependabot version updates.
-# Документация: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Все коммиты идут с префиксом "deps:" — он есть в нашем commitlint enum
-# и маппится в секцию "Changed" CHANGELOG.md (см. release-please-config.json).
+# All commits use the "deps:" prefix — it is in our commitlint enum
+# and maps to the "Changed" CHANGELOG.md section (see release-please-config.json).
 version: 2
 
 updates:
@@ -58,7 +58,7 @@ updates:
     commit-message:
       prefix: "deps"
     groups:
-      # React stack — major bumps идут бандлом (peer-dependencies должны двигаться вместе).
+      # React stack — major bumps move as a bundle (peer dependencies must travel together).
       react:
         patterns:
           - "react"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,29 +1,29 @@
 /**
  * Conventional Commits validator config for commitlint.
  *
- * Спека: https://www.conventionalcommits.org/en/v1.0.0/
- * Маппинг типов на секции CHANGELOG задан в release-please-config.json.
+ * Spec: https://www.conventionalcommits.org/en/v1.0.0/
+ * The mapping of types to CHANGELOG sections is defined in release-please-config.json.
  *
- * Допустимые типы коммитов:
- *   feat     — новая функциональность (bump MINOR; pre-1.0 — bump PATCH согласно SemVer §4)
- *   fix      — исправление бага (bump PATCH)
- *   perf     — оптимизация без изменения API (CHANGELOG: Changed)
- *   refactor — рефакторинг без изменения поведения (CHANGELOG: Changed)
- *   revert   — откат предыдущего коммита (CHANGELOG: Removed)
- *   deps     — обновление зависимостей (CHANGELOG: Changed, видимое)
- *   security — патч безопасности (CHANGELOG: Security)
- *   docs     — документация (скрыто из CHANGELOG)
- *   chore    — служебные задачи (скрыто)
- *   test     — добавление/правка тестов (скрыто)
- *   ci       — конфигурация CI (скрыто)
- *   build    — сборка/Docker (скрыто)
- *   style    — форматирование (скрыто)
+ * Allowed commit types:
+ *   feat     — new functionality (bumps MINOR; pre-1.0 — bumps PATCH per SemVer §4)
+ *   fix      — bug fix (bumps PATCH)
+ *   perf     — performance, no API change (CHANGELOG: Changed)
+ *   refactor — refactor with no behavior change (CHANGELOG: Changed)
+ *   revert   — revert of a previous commit (CHANGELOG: Removed)
+ *   deps     — dependency updates (CHANGELOG: Changed, visible)
+ *   security — security patch (CHANGELOG: Security)
+ *   docs     — documentation (hidden from CHANGELOG)
+ *   chore    — housekeeping (hidden)
+ *   test     — adding/fixing tests (hidden)
+ *   ci       — CI configuration (hidden)
+ *   build    — build / Docker (hidden)
+ *   style    — formatting (hidden)
  *
- * BREAKING CHANGE — указывается в footer или восклицательным знаком после типа
- *   (feat!: ..., fix!: ...). До 1.0.0 не бампит MAJOR (см. SemVer §4),
- *   после 1.0.0 — обязан бампить MAJOR.
+ * BREAKING CHANGE — declared in the footer or with an exclamation mark after the type
+ *   (feat!: ..., fix!: ...). Before 1.0.0 it does not bump MAJOR (see SemVer §4),
+ *   after 1.0.0 it must bump MAJOR.
  *
- * Примеры:
+ * Examples:
  *   feat(bitrix): sanitize PII in comment payload
  *   fix(report): correct LLM token counter for Russian text
  *   chore(deps): bump phpoffice/phpword to 1.4.1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,13 +1,13 @@
 # Lefthook — Git hooks manager.
-# Документация: https://lefthook.dev/
+# Documentation: https://lefthook.dev/
 #
-# Установка хуков (один раз после клона репозитория):
+# Install hooks (once, after cloning the repository):
 #   npx lefthook install
 #
-# Хуки проверяют:
-#   commit-msg → формат сообщения коммита (Conventional Commits)
-#   pre-commit → имя ветки (Conventional Branch) + линтеры на staged-файлах
-#   pre-push   → быстрые тесты (опционально)
+# What the hooks check:
+#   commit-msg → commit message format (Conventional Commits)
+#   pre-commit → branch name (Conventional Branch) + linters on staged files
+#   pre-push   → fast tests (optional)
 
 commit-msg:
   commands:
@@ -18,7 +18,7 @@ pre-commit:
   parallel: true
   commands:
     branch-name:
-      # Conventional Branch — допустимые формы:
+      # Conventional Branch — accepted forms:
       #   <type>/<slug>                  feat/conventional-branches
       #   <type>/<issue#>                feat/4
       #   <type>/#<issue#>               feat/#4
@@ -26,35 +26,35 @@ pre-commit:
       #   <type>/#<issue#>-<slug>        feat/#9-conventional-branches
       #   release/<MAJOR>.<MINOR>.<PATCH>     release/0.2.0
       #
-      # Slug опционален (можно ограничиться номером issue).
-      # Префикс '#' перед номером — опционален (для совместимости с GitHub-стилем).
-      # master/main/HEAD игнорируются — на них не коммитят напрямую.
+      # The slug is optional (the issue number alone is fine).
+      # The '#' prefix before the number is optional (matches GitHub's style).
+      # master/main/HEAD are skipped — direct commits aren't expected on them.
       run: |
         BRANCH=$(git rev-parse --abbrev-ref HEAD)
         if [ "$BRANCH" = "master" ] || [ "$BRANCH" = "main" ] || [ "$BRANCH" = "HEAD" ]; then
           exit 0
         fi
-        # Release-ветки: версии с точками (release/X.Y.Z или release/X.Y.Z-rc1).
+        # Release branches: dotted versions (release/X.Y.Z or release/X.Y.Z-rc1).
         if echo "$BRANCH" | grep -qE '^release/[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)?$'; then
           exit 0
         fi
-        # Все остальные типы: <type>/[#]<slug-or-issue>
+        # All other types: <type>/[#]<slug-or-issue>
         if echo "$BRANCH" | grep -qE '^(feat|fix|hotfix|chore|docs|refactor|perf|test|ci|build|style|security|deps)/#?[a-z0-9]+(-[a-z0-9]+)*$'; then
           exit 0
         fi
         echo ""
-        echo "✗ Имя ветки '$BRANCH' не соответствует Conventional Branch."
+        echo "✗ Branch name '$BRANCH' does not match Conventional Branch."
         echo ""
-        echo "  Формат: <type>/<slug>            или"
-        echo "          <type>/<issue#>          или"
-        echo "          <type>/#<issue#>         или"
-        echo "          <type>/<issue#>-<slug>   или"
+        echo "  Format: <type>/<slug>            or"
+        echo "          <type>/<issue#>          or"
+        echo "          <type>/#<issue#>         or"
+        echo "          <type>/<issue#>-<slug>   or"
         echo "          <type>/#<issue#>-<slug>"
         echo ""
-        echo "  Типы:   feat fix hotfix chore docs refactor perf test ci build style security deps"
-        echo "          release  (только для версий: release/X.Y.Z)"
+        echo "  Types:  feat fix hotfix chore docs refactor perf test ci build style security deps"
+        echo "          release  (versions only: release/X.Y.Z)"
         echo ""
-        echo "  Примеры:"
+        echo "  Examples:"
         echo "    feat/4"
         echo "    feat/#4"
         echo "    feat/9-conventional-branches"
@@ -63,7 +63,7 @@ pre-commit:
         echo "    chore/update-deps"
         echo "    release/0.2.0"
         echo ""
-        echo "  Чтобы переименовать: git branch -m <new-name>"
+        echo "  To rename: git branch -m <new-name>"
         echo ""
         exit 1
     pint:
@@ -87,7 +87,7 @@ pre-commit:
         - merge
         - rebase
 
-# pre-push можно включить когда тесты будут стабильно зелёными.
+# pre-push can be enabled once the tests are stably green.
 # pre-push:
 #   commands:
 #     phpunit:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "report-generator-tooling",
   "private": true,
   "version": "0.0.0",
-  "description": "Repository-level dev tooling (lefthook git hooks + commitlint). Не путать с frontend/package.json — это отдельная зона ответственности.",
+  "description": "Repository-level dev tooling (lefthook git hooks + commitlint). Not to be confused with frontend/package.json — that's a separate concern.",
   "scripts": {
     "prepare": "lefthook install",
     "commitlint": "commitlint --edit"


### PR DESCRIPTION
## Summary

Translates contributor-facing surfaces that were still Russian after PR #88:

- `.github/PULL_REQUEST_TEMPLATE.md` — full body
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml` — form labels, descriptions, placeholders (structural keys, `title:` CC prefixes, `labels:`, `id:` and `type:` untouched)
- `.github/dependabot.yml` — comments only (8 lines: header, 4 ASCII section dividers, react-stack inline note); all keys/values/patterns/schedules untouched
- `lefthook.yml` — comments **plus** the developer-facing `echo` strings inside the `branch-name` pre-commit script. The echo lines aren't comments, but they're tooling output rendered when a contributor breaks the Conventional Branch rule — leaving them Russian while CONTRIBUTING.md mandates English everywhere is internally inconsistent.
- `commitlint.config.js` — top JSDoc block (spec link + type-purpose mapping + BREAKING CHANGE note + examples). `module.exports = { ... }` body untouched.
- `package.json` — `description` field (1 line)

`8 files changed, 88 insertions(+), 88 deletions(-)` — pure line-by-line replacement.

## Verification

- [x] `git grep -P '[\x{0400}-\x{04FF}]'` against the 8 changed files → zero hits
- [x] `node --check commitlint.config.js`
- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json'))"`
- [x] `python -c "import yaml; yaml.safe_load(open(...))"` for all 5 yml files
- [x] lefthook `branch-name` + `commitlint` hooks pass locally
- [x] CI green on this PR
- [ ] After merge: open Issues → New issue, verify bug/feature templates and discussion link render in English

## Out of scope

- Backend exception messages and PHP/test comments (sub-issue #87)
- Russian-by-design product surface (frontend UI, LLM prompts, Word labels)

Closes #86
Refs #84