### PR TITLE
chore(backend): translate exception messages and PHP comments to English

### DIFF
--- a/backend/app/Domain/Sync/Actions/EnsureTasksForPeriod.php
+++ b/backend/app/Domain/Sync/Actions/EnsureTasksForPeriod.php
@@ -18,7 +18,7 @@ use RuntimeException;
  *
  * When Bitrix24 returns ACCESS_DENIED or TASK_NOT_FOUND (mapped to null by
  * tryGetTask), a stub record is stored with title=null so downstream report
- * rendering can label the task "Задача без названия (#ID)" / "Untitled (#ID)".
+ * rendering can label the task as "Untitled (#ID)".
  *
  * Infrastructure errors (connection, 5xx) are logged and skipped so one bad
  * task cannot break the whole sync. This action is idempotent: calling it

--- a/backend/app/Exceptions/InvalidTokenException.php
+++ b/backend/app/Exceptions/InvalidTokenException.php
@@ -14,7 +14,7 @@ final class InvalidTokenException extends RuntimeException
         ?Throwable $previous = null,
     ) {
         parent::__construct(
-            "Токен {$service} невалиден или истёк. Обновите его в настройках.",
+            "{$service} token is invalid or expired. Update it in settings.",
             401,
             $previous,
         );

--- a/backend/app/Exceptions/NoDataException.php
+++ b/backend/app/Exceptions/NoDataException.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 final class NoDataException extends RuntimeException
 {
-    public function __construct(string $message = 'Нет данных для формирования отчёта. Выполните синхронизацию или проверьте настройки.')
+    public function __construct(string $message = 'No data available to generate the report. Run a sync or check your settings.')
     {
         parent::__construct($message, 422);
     }

--- a/backend/app/Exceptions/ServiceUnavailableException.php
+++ b/backend/app/Exceptions/ServiceUnavailableException.php
@@ -15,7 +15,7 @@ final class ServiceUnavailableException extends RuntimeException
         ?Throwable $previous = null,
     ) {
         parent::__construct(
-            $message !== '' ? $message : "Не удалось подключиться к {$service}. Проверьте доступность и попробуйте позже.",
+            $message !== '' ? $message : "Failed to connect to {$service}. Check availability and try again later.",
             503,
             $previous,
         );


### PR DESCRIPTION
## Summary

Final tranche of the repo translation initiative. Touches the smallest surface of the three PRs:

- **3 exception classes** — translated the constructor's default `$message`:
  - `NoDataException`: "Нет данных…" → "No data available to generate the report. Run a sync or check your settings."
  - `InvalidTokenException`: "Токен … невалиден…" → "{$service} token is invalid or expired. Update it in settings."
  - `ServiceUnavailableException`: "Не удалось подключиться…" → "Failed to connect to {$service}. Check availability and try again later."

- **`EnsureTasksForPeriod.php`** — collapsed a bilingual placeholder example in a docblock to English-only (`"Untitled (#ID)"`).

`4 files changed, 4 insertions(+), 4 deletions(-)`.

## Out of scope (Russian by product design — left untouched)

- LLM prompts in `app/Infrastructure/LLM/{Claude,OpenAi}Provider.php`
- Word export content in `app/Infrastructure/Report/WordExporter.php` and `app/Console/Commands/TestWordExport.php`
- Prompt-export labels in `app/Infrastructure/Report/PromptExportService.php` and `app/Domain/Report/Services/PromptExportDataAssembler.php`
- Fallback display strings in `app/Domain/Report/Queries/{GetReportPreview,GetMonthlyReportData}.php`
- Default system prompt in `backend/config/llm.php`
- Test fixtures in `backend/tests/**` (mirror production strings on purpose)

## Verification

- [x] Pint `--test` → 253 files, no issues (also ran in pre-commit hook on staged files)
- [x] PHPStan level 10 + Larastan → no errors (also pre-commit)
- [x] PHPUnit → 350 passed, 920 assertions, 0 failed
- [x] No tests assert on the Russian exception messages (grepped the originals — zero hits)
- [x] `git grep -P '[\x{0400}-\x{04FF}]'` against `backend/app/Exceptions/**` → zero hits
- [ ] CI green on this PR

Closes #87
Refs #84