### PR TITLE
chore: translate remaining Russian comments (.gitignore + migration docblock)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,19 @@
-# IDE и редакторы
+# IDEs and editors
 /.idea/
 /.vscode/
 *.swp
 *.swo
 
-# Окружение
+# Environment
 .env
 .env.*
 !.env.example
 
-# ОС
+# OS
 .DS_Store
 Thumbs.db
 
-# Агенты
+# Agents
 CLAUDE.md
 
 node_modules/

--- a/backend/database/migrations/2026_04_18_213745_make_task_title_nullable.php
+++ b/backend/database/migrations/2026_04_18_213745_make_task_title_nullable.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Facades\Schema;
  *
  * Stub tasks are created when Bitrix24 returns 403 (ACCESS_DENIED) or 404
  * (TASK_NOT_FOUND) for a task referenced by a time-tracking entry. These
- * stubs carry title=null and are rendered as "Задача без названия (#ID)"
- * in the report.
+ * stubs carry title=null and are rendered with an "Untitled (#ID)"
+ * placeholder in the report.
  *
  * NOTE on rollback: the down() migration restores the NOT NULL constraint.
  * Any stub rows that were inserted with title=null will violate this


### PR DESCRIPTION
## Summary

Two Russian-comment leftovers surfaced after the three-PR translation initiative merged (parent #84, PRs #88 / #89 / #100). Neither file was in the original scope lists.

- **`.gitignore`** — four section headers (`# IDE и редакторы`, `# Окружение`, `# ОС`, `# Агенты`) translated to English. Path entries untouched.
- **`backend/database/migrations/2026_04_18_213745_make_task_title_nullable.php`** — one PHPDoc sentence quoting the Russian runtime label rephrased as a structural English description with an `"Untitled (#ID)"` placeholder example, matching the convention established for `EnsureTasksForPeriod.php` in #100.

The actual runtime label in the Word export remains Russian by design — only the docblock prose changed.

## Scope

- Comments only. No runtime behavior, no schema, no migrations re-run.
- Russian-by-design product surfaces (frontend UI, LLM prompts, Word export, fixtures) deliberately untouched.

## Verification

- `git grep -P '[\x{0400}-\x{04FF}]' -- .gitignore backend/database/` → no matches.
- Local Pint/PHPStan not run (Docker stack not up in this environment); change is descriptive prose inside a `/** */` block with no type annotations, so it cannot affect either tool. CI will confirm.

Refs #84
Closes #103 