### PR TITLE
ci: group commitlint major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,9 +101,6 @@ updates:
     commit-message:
       prefix: "deps"
     groups:
-      # All @commitlint/* packages share an internal API and are released as one
-      # synchronized major — group every semver level so majors land in a single PR.
-      # See #105.
       commitlint:
         patterns:
           - "@commitlint/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -101,10 +101,12 @@ updates:
     commit-message:
       prefix: "deps"
     groups:
+      # All @commitlint/* packages share an internal API and are released as one
+      # synchronized major — group every semver level so majors land in a single PR.
+      # See #105.
       commitlint:
         patterns:
           - "@commitlint/*"
-        update-types: ["minor", "patch"]
 
   # ─── GitHub Actions ───────────────────────────────────────────
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Drop the `update-types: ["minor", "patch"]` filter from the `commitlint` group in `.github/dependabot.yml`.
- Add an inline comment explaining the coupling between `@commitlint/*` packages.

After this change, major bumps of any `@commitlint/*` package will arrive as a single grouped Dependabot PR (instead of N separate PRs as happened with #93 / #94 for the v19 → v21 cycle).

Closes #105

## Test plan

- [ ] Wait for the next `@commitlint/*` major (or close #93 + #94 and run `@dependabot recreate` once this lands) and confirm a single grouped PR appears.
- [ ] No regressions in the existing `commitlint` CI job on this PR.