### PR TITLE
fix(sync): make credential resolution survive APP_KEY rotation

### DIFF
--- a/backend/app/Console/Commands/SettingsResetCommand.php
+++ b/backend/app/Console/Commands/SettingsResetCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class SettingsResetCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'settings:reset {--force : Skip confirmation prompt}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Clear encrypted credentials (gitlab_token, bitrix24_api_key, llm_api_key) from settings';
+
+    public function handle(): int
+    {
+        $force = (bool) $this->option('force');
+
+        if (! $force && ! $this->confirm('Reset encrypted credentials (gitlab_token, bitrix24_api_key, llm_api_key)?')) {
+            $this->info('Aborted.');
+
+            return self::SUCCESS;
+        }
+
+        $affected = DB::table('settings')->update([
+            'gitlab_token'     => null,
+            'bitrix24_api_key' => null,
+            'llm_api_key'      => null,
+        ]);
+
+        $this->info("Cleared encrypted credentials in {$affected} settings row(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Http/Controllers/SettingsController.php
+++ b/backend/app/Http/Controllers/SettingsController.php
@@ -54,9 +54,20 @@ class SettingsController extends Controller
             'developer_position'      => $settings?->developer_position,
             'enriched_prompt_enabled' => $settings === null ? true : $settings->enriched_prompt_enabled,
             'sync_schedule_time'      => $settings === null ? '03:00' : $settings->sync_schedule_time,
-            'has_gitlab_token'        => $settings?->gitlab_token !== null,
-            'has_bitrix24_api_key'    => $settings?->bitrix24_api_key !== null,
-            'has_llm_api_key'         => $settings?->llm_api_key !== null,
+            'has_gitlab_token'        => $this->hasEncrypted($settings, 'gitlab_token'),
+            'has_bitrix24_api_key'    => $this->hasEncrypted($settings, 'bitrix24_api_key'),
+            'has_llm_api_key'         => $this->hasEncrypted($settings, 'llm_api_key'),
         ];
+    }
+
+    private function hasEncrypted(?Setting $settings, string $column): bool
+    {
+        if ($settings === null) {
+            return false;
+        }
+
+        $raw = $settings->getRawOriginal($column);
+
+        return is_string($raw) && $raw !== '';
     }
 }

--- a/backend/app/Providers/Bitrix24ServiceProvider.php
+++ b/backend/app/Providers/Bitrix24ServiceProvider.php
@@ -7,6 +7,8 @@ namespace App\Providers;
 use App\Domain\Settings\Models\Setting;
 use App\Infrastructure\Bitrix24\Bitrix24Client;
 use App\Domain\Bitrix24\Services\Bitrix24ClientInterface;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class Bitrix24ServiceProvider extends ServiceProvider
@@ -18,10 +20,27 @@ class Bitrix24ServiceProvider extends ServiceProvider
 
             /** @var string $url */
             $url = config('services.bitrix24.url', '');
+
             /** @var string $userId */
-            $userId = $setting->bitrix24_user_id ?? config('services.bitrix24.user_id', '');
+            $userId = config('services.bitrix24.user_id', '');
+            if ($setting !== null && $setting->bitrix24_user_id !== null) {
+                $userId = (string) $setting->bitrix24_user_id;
+            }
+
             /** @var string $apiKey */
-            $apiKey = $setting->bitrix24_api_key ?? config('services.bitrix24.api_key', '');
+            $apiKey = config('services.bitrix24.api_key', '');
+
+            try {
+                if ($setting !== null && $setting->bitrix24_api_key !== null) {
+                    $apiKey = $setting->bitrix24_api_key;
+                }
+                // @phpstan-ignore catch.neverThrown (encrypted cast throws at runtime; static analysis can't see it)
+            } catch (DecryptException $e) {
+                Log::warning(
+                    'Bitrix24 API key decryption failed, falling back to config. Run "php artisan settings:reset" and re-enter credentials in Settings.',
+                    ['error' => $e->getMessage()],
+                );
+            }
 
             return new Bitrix24Client(
                 url: $url,

--- a/backend/app/Providers/GitLabServiceProvider.php
+++ b/backend/app/Providers/GitLabServiceProvider.php
@@ -7,6 +7,8 @@ namespace App\Providers;
 use App\Domain\Settings\Models\Setting;
 use App\Infrastructure\GitLab\GitLabClient;
 use App\Domain\GitLab\Services\GitLabClientInterface;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 final class GitLabServiceProvider extends ServiceProvider
@@ -17,7 +19,20 @@ final class GitLabServiceProvider extends ServiceProvider
             $setting = Setting::query()->first();
 
             /** @var string $token */
-            $token = $setting->gitlab_token ?? config('services.gitlab.token', '');
+            $token = config('services.gitlab.token', '');
+
+            try {
+                if ($setting !== null && $setting->gitlab_token !== null) {
+                    $token = $setting->gitlab_token;
+                }
+                // @phpstan-ignore catch.neverThrown (encrypted cast throws at runtime; static analysis can't see it)
+            } catch (DecryptException $e) {
+                Log::warning(
+                    'GitLab token decryption failed, falling back to config. Run "php artisan settings:reset" and re-enter credentials in Settings.',
+                    ['error' => $e->getMessage()],
+                );
+            }
+
             /** @var string $url */
             $url = config('services.gitlab.url', 'https://gitlab.com');
 

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -36,15 +36,15 @@ return [
     ],
 
     'gitlab' => [
-        'token'    => env('GITLAB_TOKEN'),
+        'token'    => env('GITLAB_TOKEN', ''),
         'url'      => env('GITLAB_URL', 'https://gitlab.com'),
         'username' => env('GITLAB_USERNAME'),
     ],
 
     'bitrix24' => [
-        'url'     => env('BITRIX24_URL'),
-        'user_id' => env('BITRIX24_USER_ID'),
-        'api_key' => env('BITRIX24_API_KEY'),
+        'url'     => env('BITRIX24_URL', ''),
+        'user_id' => env('BITRIX24_USER_ID', ''),
+        'api_key' => env('BITRIX24_API_KEY', ''),
     ],
 
 ];

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:S1AadeqGXw9BhfyShxTpeGjS/ls4wUi+3unsDWIdYQ8="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/backend/tests/Feature/Api/SettingsApiTest.php
+++ b/backend/tests/Feature/Api/SettingsApiTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Api;
 
 use App\Domain\Settings\Models\Setting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class SettingsApiTest extends TestCase
@@ -77,5 +78,36 @@ class SettingsApiTest extends TestCase
         $this->assertArrayNotHasKey('gitlab_token', $content);
         $this->assertArrayNotHasKey('bitrix24_api_key', $content);
         $this->assertArrayNotHasKey('llm_api_key', $content);
+    }
+
+    public function test_get_settings_survives_corrupted_encrypted_columns(): void
+    {
+        // Insert raw garbage that looks like a base64 envelope but will fail MAC validation.
+        // The controller reads raw values via getRawOriginal(), so it must not attempt decryption.
+        DB::table('settings')->insert([
+            'gitlab_token'            => 'eyJpdiI6ImNvcnJ1cHRlZCIsInZhbHVlIjoiYmFkIn0=',
+            'gitlab_username'         => null,
+            'gitlab_email'            => null,
+            'bitrix24_api_key'        => 'eyJpdiI6ImNvcnJ1cHRlZCIsInZhbHVlIjoiYmFkIn0=',
+            'bitrix24_user_id'        => null,
+            'llm_provider'            => 'claude',
+            'llm_api_key'             => 'eyJpdiI6ImNvcnJ1cHRlZCIsInZhbHVlIjoiYmFkIn0=',
+            'llm_system_prompt'       => null,
+            'enriched_prompt_enabled' => true,
+            'developer_name'          => null,
+            'developer_position'      => null,
+            'sync_schedule_time'      => '03:00',
+            'created_at'              => now(),
+            'updated_at'              => now(),
+        ]);
+
+        $response = $this->getJson('/api/settings');
+
+        $response->assertOk()
+            ->assertJson([
+                'has_gitlab_token'     => true,
+                'has_bitrix24_api_key' => true,
+                'has_llm_api_key'      => true,
+            ]);
     }
 }

--- a/backend/tests/Feature/Commands/SettingsResetCommandTest.php
+++ b/backend/tests/Feature/Commands/SettingsResetCommandTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commands;
+
+use App\Domain\Settings\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\PendingCommand;
+use Tests\TestCase;
+
+class SettingsResetCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_force_flag_clears_encrypted_fields(): void
+    {
+        Setting::factory()->create([
+            'gitlab_token'     => 'glpat-real-token-abc123',
+            'bitrix24_api_key' => 'bitrix-key-xyz789',
+            'llm_api_key'      => 'sk-ant-api03-fakekey',
+        ]);
+
+        $command = $this->artisan('settings:reset', ['--force' => true]);
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->expectsOutputToContain('Cleared encrypted credentials in 1 settings row(s).');
+        $command->run();
+
+        $raw = DB::table('settings')->first();
+        $this->assertNotNull($raw);
+        $this->assertNull($raw->gitlab_token);
+        $this->assertNull($raw->bitrix24_api_key);
+        $this->assertNull($raw->llm_api_key);
+    }
+
+    public function test_confirmation_aborts_without_force(): void
+    {
+        Setting::factory()->create([
+            'gitlab_token' => 'glpat-real-token-abc123',
+        ]);
+
+        $rawBefore = DB::table('settings')->value('gitlab_token');
+
+        $command = $this->artisan('settings:reset');
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->expectsConfirmation('Reset encrypted credentials (gitlab_token, bitrix24_api_key, llm_api_key)?', 'no');
+        $command->expectsOutputToContain('Aborted.');
+        $command->run();
+
+        $rawAfter = DB::table('settings')->value('gitlab_token');
+        $this->assertSame($rawBefore, $rawAfter);
+        $this->assertNotNull($rawAfter);
+    }
+
+    public function test_confirmation_yes_clears_fields(): void
+    {
+        Setting::factory()->create([
+            'gitlab_token'     => 'glpat-real-token-abc123',
+            'bitrix24_api_key' => 'bitrix-key-xyz789',
+            'llm_api_key'      => 'sk-ant-api03-fakekey',
+        ]);
+
+        $command = $this->artisan('settings:reset');
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->expectsConfirmation('Reset encrypted credentials (gitlab_token, bitrix24_api_key, llm_api_key)?', 'yes');
+        $command->expectsOutputToContain('Cleared encrypted credentials in 1 settings row(s).');
+        $command->run();
+
+        $raw = DB::table('settings')->first();
+        $this->assertNotNull($raw);
+        $this->assertNull($raw->gitlab_token);
+        $this->assertNull($raw->bitrix24_api_key);
+        $this->assertNull($raw->llm_api_key);
+    }
+
+    public function test_runs_on_empty_settings_table(): void
+    {
+        $command = $this->artisan('settings:reset', ['--force' => true]);
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->expectsOutputToContain('0 settings row(s)');
+        $command->assertExitCode(0);
+    }
+
+    public function test_leaves_non_encrypted_fields_intact(): void
+    {
+        Setting::factory()->create([
+            'gitlab_username'  => 'john',
+            'developer_name'   => 'John',
+            'bitrix24_user_id' => '42',
+            'gitlab_token'     => 'glpat-real-token-abc123',
+        ]);
+
+        $command = $this->artisan('settings:reset', ['--force' => true]);
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->run();
+
+        $raw = DB::table('settings')->first();
+        $this->assertNotNull($raw);
+        $this->assertSame('john', $raw->gitlab_username);
+        $this->assertSame('John', $raw->developer_name);
+        $this->assertSame('42', $raw->bitrix24_user_id);
+        $this->assertNull($raw->gitlab_token);
+        $this->assertNull($raw->bitrix24_api_key);
+        $this->assertNull($raw->llm_api_key);
+    }
+}

--- a/backend/tests/Feature/Providers/Bitrix24ServiceProviderDecryptTest.php
+++ b/backend/tests/Feature/Providers/Bitrix24ServiceProviderDecryptTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Providers;
+
+use App\Domain\Bitrix24\Services\Bitrix24ClientInterface;
+use App\Domain\Settings\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class Bitrix24ServiceProviderDecryptTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_corrupted_bitrix24_api_key_falls_back_to_config_without_throwing(): void
+    {
+        // Insert a raw value that looks like a base64 envelope but has invalid MAC/structure.
+        // The encrypted cast will try to decrypt it and throw DecryptException.
+        DB::table('settings')->insert([
+            'gitlab_token'            => null,
+            'gitlab_username'         => null,
+            'gitlab_email'            => null,
+            'bitrix24_api_key'        => 'eyJpdiI6ImNvcnJ1cHRlZCIsInZhbHVlIjoiYmFkIn0=',
+            'bitrix24_user_id'        => null,
+            'llm_provider'            => 'claude',
+            'llm_api_key'             => null,
+            'llm_system_prompt'       => null,
+            'enriched_prompt_enabled' => true,
+            'developer_name'          => null,
+            'developer_position'      => null,
+            'sync_schedule_time'      => '03:00',
+            'created_at'              => now(),
+            'updated_at'              => now(),
+        ]);
+
+        $warnings = [];
+        Log::listen(function (object $event) use (&$warnings): void {
+            /** @var object{level: string} $event */
+            if (property_exists($event, 'level') && $event->level === 'warning') {
+                $warnings[] = $event;
+            }
+        });
+
+        $this->app->forgetInstance(Bitrix24ClientInterface::class);
+
+        $client = $this->app->make(Bitrix24ClientInterface::class);
+
+        $this->assertInstanceOf(Bitrix24ClientInterface::class, $client);
+
+        // The provider must have logged a warning about the decryption failure.
+        $this->assertNotEmpty($warnings, 'Expected at least one warning log entry for decryption failure');
+    }
+
+    public function test_valid_bitrix24_api_key_resolves_normally(): void
+    {
+        Setting::factory()->create(['bitrix24_api_key' => 'valid-api-key-abc']);
+
+        $warnings = [];
+        Log::listen(function (object $event) use (&$warnings): void {
+            /** @var object{level: string} $event */
+            if (property_exists($event, 'level') && $event->level === 'warning') {
+                $warnings[] = $event;
+            }
+        });
+
+        $this->app->forgetInstance(Bitrix24ClientInterface::class);
+
+        $client = $this->app->make(Bitrix24ClientInterface::class);
+
+        $this->assertInstanceOf(Bitrix24ClientInterface::class, $client);
+
+        // No warning must be logged when the key is intact.
+        $this->assertEmpty($warnings, 'Expected no warning log entries for a valid key');
+    }
+
+    public function test_null_bitrix24_api_key_uses_config_fallback(): void
+    {
+        // No Setting row at all — provider reads from config instead.
+        $this->app->forgetInstance(Bitrix24ClientInterface::class);
+
+        $client = $this->app->make(Bitrix24ClientInterface::class);
+
+        $this->assertInstanceOf(Bitrix24ClientInterface::class, $client);
+    }
+}

--- a/backend/tests/Feature/Providers/GitLabServiceProviderDecryptTest.php
+++ b/backend/tests/Feature/Providers/GitLabServiceProviderDecryptTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Providers;
+
+use App\Domain\GitLab\Services\GitLabClientInterface;
+use App\Domain\Settings\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class GitLabServiceProviderDecryptTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_corrupted_gitlab_token_falls_back_to_config_without_throwing(): void
+    {
+        // Insert a raw value that looks like a base64 envelope but has invalid MAC/structure.
+        // The encrypted cast will try to decrypt it and throw DecryptException.
+        DB::table('settings')->insert([
+            'gitlab_token'            => 'eyJpdiI6ImNvcnJ1cHRlZCIsInZhbHVlIjoiYmFkIn0=',
+            'gitlab_username'         => null,
+            'gitlab_email'            => null,
+            'bitrix24_api_key'        => null,
+            'bitrix24_user_id'        => null,
+            'llm_provider'            => 'claude',
+            'llm_api_key'             => null,
+            'llm_system_prompt'       => null,
+            'enriched_prompt_enabled' => true,
+            'developer_name'          => null,
+            'developer_position'      => null,
+            'sync_schedule_time'      => '03:00',
+            'created_at'              => now(),
+            'updated_at'              => now(),
+        ]);
+
+        $warnings = [];
+        Log::listen(function (object $event) use (&$warnings): void {
+            /** @var object{level: string} $event */
+            if (property_exists($event, 'level') && $event->level === 'warning') {
+                $warnings[] = $event;
+            }
+        });
+
+        $this->app->forgetInstance(GitLabClientInterface::class);
+
+        $client = $this->app->make(GitLabClientInterface::class);
+
+        $this->assertInstanceOf(GitLabClientInterface::class, $client);
+
+        // The provider must have logged a warning about the decryption failure.
+        $this->assertNotEmpty($warnings, 'Expected at least one warning log entry for decryption failure');
+    }
+
+    public function test_valid_gitlab_token_resolves_normally(): void
+    {
+        Setting::factory()->create(['gitlab_token' => 'valid-token-xyz']);
+
+        $warnings = [];
+        Log::listen(function (object $event) use (&$warnings): void {
+            /** @var object{level: string} $event */
+            if (property_exists($event, 'level') && $event->level === 'warning') {
+                $warnings[] = $event;
+            }
+        });
+
+        $this->app->forgetInstance(GitLabClientInterface::class);
+
+        $client = $this->app->make(GitLabClientInterface::class);
+
+        $this->assertInstanceOf(GitLabClientInterface::class, $client);
+
+        // No warning must be logged when the token is intact.
+        $this->assertEmpty($warnings, 'Expected no warning log entries for a valid token');
+    }
+
+    public function test_null_gitlab_token_uses_config_fallback(): void
+    {
+        // No Setting row at all — provider reads from config instead.
+        $this->app->forgetInstance(GitLabClientInterface::class);
+
+        $client = $this->app->make(GitLabClientInterface::class);
+
+        $this->assertInstanceOf(GitLabClientInterface::class, $client);
+    }
+}


### PR DESCRIPTION

Closes #110 

## Summary

- Service providers and `SettingsController` no longer crash when stored
  encrypted credentials can't be decrypted with the current `APP_KEY` —
  callers see a graceful fallback to config defaults and an actionable
  log warning instead of an unhandled `DecryptException`.
- New artisan command `settings:reset` clears the corrupted encrypted
  columns (`gitlab_token`, `bitrix24_api_key`, `llm_api_key`) via raw DB
  update, bypassing the Eloquent cast so the recovery path itself
  doesn't trip on the broken decrypt.
- `GET /api/settings` survives a corrupted state (reads `has_*_token`
  flags via `getRawOriginal()`), so the Settings UI keeps loading and
  the user has an in-app path to re-enter credentials.

## Changes

### Defensive credential resolution

- `app/Providers/GitLabServiceProvider.php`,
  `app/Providers/Bitrix24ServiceProvider.php` — wrap encrypted-attribute
  reads in `try { … } catch (DecryptException $e)`; log a warning that
  references `settings:reset`; fall back to `config()`. The sync action
  now reaches its own catch block and writes a meaningful
  `SyncLog::failed` row instead of crashing the queue worker at DI time.
- `app/Http/Controllers/SettingsController.php` — `has_*_token` flags
  now read via `getRawOriginal()` so the cast never fires on GET.
- `config/services.php` — explicit `''` defaults for `GITLAB_TOKEN`,
  `BITRIX24_URL`, `BITRIX24_USER_ID`, `BITRIX24_API_KEY`. Plain `env()`
  returns `null`, and `config(key, '')` does not substitute the default
  when the key exists with a `null` value — discovered during test runs.

### Recovery tool

- `app/Console/Commands/SettingsResetCommand.php` — `php artisan
  settings:reset [--force]`. Uses `DB::table('settings')->update([...])`
  to null the three encrypted columns directly, bypassing the cast.
  `--force` skips the confirmation prompt for non-interactive runs
  (CI, `docker compose exec`).

### Tests (15 cases, 54 assertions)

- `tests/Feature/Commands/SettingsResetCommandTest.php` — `--force`,
  confirmation accept/reject, empty-table run, non-encrypted columns
  untouched.
- `tests/Feature/Providers/GitLabServiceProviderDecryptTest.php`,
  `tests/Feature/Providers/Bitrix24ServiceProviderDecryptTest.php` —
  corrupted token resolves to config fallback with logged warning;
  valid token resolves without warning; missing setting row resolves
  cleanly.
- `tests/Feature/Api/SettingsApiTest.php` — new
  `test_get_settings_survives_corrupted_encrypted_columns` covers the
  500-on-load regression.

### Test infrastructure

- `backend/phpunit.xml` — pinned a test `APP_KEY`. Required because the
  new tests need an initialised `Encrypter` and the worktree has no
  `.env` (it's `.gitignore`d), so a fresh `docker run` against the
  worktree was failing with `MissingAppKeyException`.

## Test plan

- [ ] `docker compose exec app ./vendor/bin/phpunit --filter 'SettingsResetCommandTest|GitLabServiceProviderDecryptTest|Bitrix24ServiceProviderDecryptTest|SettingsApiTest'` → 15/15 green.
- [ ] `docker compose exec app ./vendor/bin/phpstan analyse --no-progress` → 0 errors.
- [ ] `docker compose exec app ./vendor/bin/pint --test backend/app backend/tests` → no changes.
- [ ] Manual repro of the original bug:
  1. Save credentials through the Settings UI.
  2. `php artisan key:generate` (or restore a `.env` with a different `APP_KEY`).
  3. `GET /api/settings` → **200** with `has_*_token: true` (was: 500).
  4. `POST /api/sync/trigger` → `SyncJob` ends in `failed` with a readable
     `error_message` (was: opaque `The MAC is invalid.`); container does
     not crash.
- [ ] Recovery flow:
  1. `docker compose exec app php artisan settings:reset --force` → reports
     `Cleared encrypted credentials in 1 settings row(s).`
  2. `GET /api/settings` → `has_*_token: false`.
  3. Re-enter credentials through the UI → next sync runs against the
     external APIs (may still fail on real auth, but no longer at the
     encryption layer).

## Notes for reviewers

- `LlmServiceProvider` was left untouched — it already wraps its setting
  read in a `\Throwable` catch, so the LLM provider already degrades
  gracefully under this scenario.
- The `@phpstan-ignore catch.neverThrown` on the new `catch
  (DecryptException)` blocks is intentional: Larastan infers
  `$setting->gitlab_token` as `string|null` from the `@property`
  docblock and cannot see that the `encrypted` cast may throw at
  runtime.