### PR TITLE
chore: normalize line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Default: auto-detect text/binary, normalize line endings on commit
+* text=auto
+
+# Always LF — executed by Linux (shell, Dockerfiles, entrypoints)
+*.sh           text eol=lf
+*.bash         text eol=lf
+Dockerfile     text eol=lf
+*.dockerfile   text eol=lf
+
+# Config files read by Linux tools in containers
+*.conf         text eol=lf
+*.yml          text eol=lf
+*.yaml         text eol=lf
+
+# Windows-native scripts — CRLF if any appear later
+*.bat          text eol=crlf
+*.cmd          text eol=crlf
+*.ps1          text eol=crlf
+
+# Binary assets — никакой конвертации
+*.png          binary
+*.jpg          binary
+*.jpeg         binary
+*.ico          binary
+*.woff         binary
+*.woff2        binary
+*.ttf          binary
+*.pdf          binary
+*.docx         binary
+*.xlsx         binary


### PR DESCRIPTION
What changes
Adds a repository-level .gitattributes that pins line endings:

*.sh, *.bash, Dockerfile, *.dockerfile, *.conf, *.yml, *.yaml → LF
*.bat, *.cmd, *.ps1 → CRLF
*.png, *.jpg, *.jpeg, *.ico, *.woff, *.woff2, *.ttf, *.pdf, *.docx, *.xlsx → binary (no conversion)
everything else → text=auto (Git-detected, LF in repo)
No source files were renormalized — git add --renormalize . produced no changes, confirming every tracked blob is already LF in the index. This PR is a preventive policy change, not a content rewrite.

Why
On a fresh clone or new worktree on Windows with core.autocrlf=true (the Git for Windows default), Git rewrites .docker/*/entrypoint.sh to CRLF in the working tree. The Linux kernel parses the shebang as /bin/sh\r and docker compose up fails with:

exec /entrypoint.sh: no such file or directory
.gitattributes overrides core.autocrlf at the repository level, so this class of failure can no longer be triggered by a contributor's local Git configuration.

Closes #111 

How to verify
On a Windows host with git config --global core.autocrlf true:

git fetch && git checkout chore/gitattributes-lf-line-endings
file .docker/app/entrypoint.sh → expect ASCII text executable (no with CRLF line terminators).
docker compose build --no-cache app && docker compose up -d → rg-app starts and stays healthy. --no-cache is required the first time so BuildKit does not reuse a layer baked from a previous CRLF checkout.
Repeat for .docker/worker/entrypoint.sh and .docker/node/entrypoint.sh.
On Linux/macOS: behavior is unchanged.

Also verified locally:

git cat-file -p :.gitattributes | od -c shows the staged blob is LF.
Lefthook pre-commit and commit-msg hooks pass; pint, phpstan, eslint are skipped (no matching staged files).
Branch name chore/gitattributes-lf-line-endings matches the Conventional Branch regex.
Checklist
done
Branch name follows Conventional Branch (chore/gitattributes-lf-line-endings)
done
PR title follows Conventional Commits (chore: normalize line endings via .gitattributes)
done
make lint and make test pass locally — not exercised, no PHP/JS/test files touched; lefthook hooks pass on commit
done
Documentation updated — N/A, no user-visible behavior changes
done
One logical change in the PR