### PR TITLE
chore(docker): enable parallel main + worktree compose runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
 REDIS_PASSWORD=your_redis_password
+
+# Host ports. Override per checkout when running multiple worktrees in parallel.
+APP_PORT=8000
+NODE_PORT=5173
+REDIS_PORT=6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .docker/app
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "${APP_PORT:-8000}:8000"
     volumes:
       - ./backend:/var/www
       - .docker/app/nginx.conf:/etc/nginx/http.d/default.conf
@@ -35,7 +35,7 @@ services:
       context: .docker/node
       dockerfile: Dockerfile
     ports:
-      - "5173:5173"
+      - "${NODE_PORT:-5173}:5173"
     volumes:
       - ./frontend:/app
       - node_modules:/app/node_modules
@@ -50,7 +50,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis-data:/data
       - .docker/redis/redis.conf:/usr/local/etc/redis/redis.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: .docker/app
       dockerfile: Dockerfile
-    container_name: rg-app
     ports:
       - "8000:8000"
     volumes:
@@ -21,7 +20,6 @@ services:
     build:
       context: .docker/worker
       dockerfile: Dockerfile
-    container_name: rg-worker
     volumes:
       - ./backend:/var/www
     depends_on:
@@ -36,7 +34,6 @@ services:
     build:
       context: .docker/node
       dockerfile: Dockerfile
-    container_name: rg-node
     ports:
       - "5173:5173"
     volumes:
@@ -52,7 +49,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: rg-redis
     ports:
       - "6379:6379"
     volumes:


### PR DESCRIPTION
## What changes

- Drop hardcoded `container_name: rg-{app,worker,node,redis}` from `docker-compose.yml`. Compose v2 now derives names from the project directory (`moronocracy-app-1` vs `<worktree-slug>-app-1`).
- Parameterize host ports via `${APP_PORT:-8000}`, `${NODE_PORT:-5173}`, `${REDIS_PORT:-6379}`. Defaults preserve the existing main-checkout behavior.
- Document the new variables in `.env.example`.

No code or call-site changes: Makefile, `lefthook.yml`, AGENTS.md and CI already use service-name-based `docker compose exec app/node ...`.

## Why

`docker compose up` in a Claude worktree (`.claude/worktrees/<slug>/`) collided with the main checkout on both container names (`rg-app` already in use) and host ports (`0.0.0.0:8000` already bound), so the two stacks could not run side by side. This made it impossible to keep the main stack up while an agent worked in an isolated worktree.

Closes # 113

## How to verify

In the main checkout (defaults — no `.env` override needed):
```bash
docker compose up -d
docker compose ps
# Expect: moronocracy-app-1, moronocracy-redis-1, etc.
#         0.0.0.0:8000->8000/tcp, 0.0.0.0:5173->5173/tcp, 0.0.0.0:6379->6379/tcp

In a worktree, with .env overriding ports:

echo "APP_PORT=8010
NODE_PORT=5183
REDIS_PORT=6389" >> .env
docker compose up -d
# Expect: <worktree-slug>-app-1 etc. on 8010/5183/6389, coexisting with the main stack
Functional checks (ran locally in a worktree at 8010/5183/6389, with the .gitattributes fix from [#112](https://github.com/Meacue/report-generator/issues/112) already in place):

docker compose exec app php -v → PHP 8.4.21 (cli)
docker compose exec redis redis-cli -a <pwd> PING → PONG
docker compose exec app nc -zv redis 6379 → redis (...:6379) open
All four containers reach Up without manual line-ending fixes.
Checklist
done
Branch name follows Conventional Branch (chore/parallel-worktree-compose)
done
PR title follows Conventional Commits
done
make lint and make test — not run (changes are infrastructure-only, no PHP/JS files touched)
done
Documentation updated (.env.example)
done
One logical change in the PR