### PR TITLE
fix(bitrix24): validate webhook URL on save and unify credential sources

### DIFF
--- a/backend/app/Domain/Settings/DTOs/ParsedWebhook.php
+++ b/backend/app/Domain/Settings/DTOs/ParsedWebhook.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\DTOs;
+
+/**
+ * Immutable representation of a Bitrix24 incoming webhook URL split into
+ * the three parts our infrastructure layer needs to assemble REST endpoints:
+ * the portal REST root, the operator user_id, and the secret api_key.
+ */
+final readonly class ParsedWebhook
+{
+    public function __construct(
+        public string $restUrl,
+        public string $userId,
+        public string $apiKey,
+    ) {
+    }
+}

--- a/backend/app/Domain/Settings/Exceptions/InvalidWebhookUrlException.php
+++ b/backend/app/Domain/Settings/Exceptions/InvalidWebhookUrlException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * Thrown when the supplied Bitrix24 webhook URL does not match the canonical
+ * `https://<portal>/rest/<user_id>/<api_key>/` shape or fails sanity checks.
+ *
+ * Extends a plain SPL exception so the parser can be tested without booting
+ * the Laravel container.
+ */
+final class InvalidWebhookUrlException extends InvalidArgumentException
+{
+}

--- a/backend/app/Domain/Settings/Models/Setting.php
+++ b/backend/app/Domain/Settings/Models/Setting.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null $gitlab_email
  * @property string|null $bitrix24_api_key
  * @property int|null $bitrix24_user_id
+ * @property string|null $bitrix24_rest_url
  * @property LlmProvider|null $llm_provider
  * @property string|null $llm_api_key
  * @property string|null $llm_system_prompt
@@ -35,6 +36,7 @@ class Setting extends Model
         'gitlab_email',
         'bitrix24_api_key',
         'bitrix24_user_id',
+        'bitrix24_rest_url',
         'llm_provider',
         'llm_api_key',
         'llm_system_prompt',

--- a/backend/app/Domain/Settings/Services/WebhookUrlParser.php
+++ b/backend/app/Domain/Settings/Services/WebhookUrlParser.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Settings\Services;
+
+use App\Domain\Settings\DTOs\ParsedWebhook;
+use App\Domain\Settings\Exceptions\InvalidWebhookUrlException;
+
+/**
+ * Parses a Bitrix24 incoming webhook URL into its three constituent parts.
+ *
+ * Expected canonical form (trailing slash optional):
+ *   https://<portal-host>[:<port>]/rest/<user_id>/<api_key>/
+ *
+ * Anything else (extra path segments, query strings, missing parts, bad
+ * characters in the api_key) is rejected with {@see InvalidWebhookUrlException}.
+ */
+final class WebhookUrlParser
+{
+    /**
+     * Regex describing the canonical webhook URL shape.
+     *
+     * Groups:
+     *   - rest: scheme + host + optional port + `/rest`
+     *   - user: numeric Bitrix24 operator id
+     *   - key:  alphanumeric webhook secret
+     */
+    private const string PATTERN = '#^(?<rest>https?://[^/\s]+(?::\d+)?/rest)/(?<user>\d+)/(?<key>[A-Za-z0-9]+)/?$#';
+
+    private const string EXPECTED_SHAPE_MESSAGE = 'Webhook URL must match https://<portal>.bitrix24.ru/rest/<user_id>/<api_key>/';
+
+    /**
+     * Minimum length of the api_key segment. Bitrix24 webhooks are typically
+     * 32 alphanumeric characters; 8 is a defensive lower bound that still
+     * rejects obvious garbage like `/rest/1/abc/`.
+     */
+    private const int MIN_API_KEY_LENGTH = 8;
+
+    public function parse(string $url): ParsedWebhook
+    {
+        $trimmed = trim($url);
+
+        if ($trimmed === '') {
+            throw new InvalidWebhookUrlException(self::EXPECTED_SHAPE_MESSAGE);
+        }
+
+        if (preg_match(self::PATTERN, $trimmed, $matches) !== 1) {
+            throw new InvalidWebhookUrlException(self::EXPECTED_SHAPE_MESSAGE);
+        }
+
+        $restUrl = $matches['rest'];
+        $userId = $matches['user'];
+        $apiKey = $matches['key'];
+
+        if ((int) $userId <= 0) {
+            throw new InvalidWebhookUrlException(self::EXPECTED_SHAPE_MESSAGE);
+        }
+
+        if (strlen($apiKey) < self::MIN_API_KEY_LENGTH) {
+            throw new InvalidWebhookUrlException(self::EXPECTED_SHAPE_MESSAGE);
+        }
+
+        return new ParsedWebhook(
+            restUrl: $restUrl,
+            userId: $userId,
+            apiKey: $apiKey,
+        );
+    }
+}

--- a/backend/app/Http/Controllers/SettingsController.php
+++ b/backend/app/Http/Controllers/SettingsController.php
@@ -49,14 +49,18 @@ class SettingsController extends Controller
             'llm_provider'     => $settings === null
                 ? LlmProvider::Claude->value
                 : $settings->llm_provider?->value,
-            'llm_system_prompt'       => $settings?->llm_system_prompt,
-            'developer_name'          => $settings?->developer_name,
-            'developer_position'      => $settings?->developer_position,
-            'enriched_prompt_enabled' => $settings === null ? true : $settings->enriched_prompt_enabled,
-            'sync_schedule_time'      => $settings === null ? '03:00' : $settings->sync_schedule_time,
-            'has_gitlab_token'        => $this->hasEncrypted($settings, 'gitlab_token'),
-            'has_bitrix24_api_key'    => $this->hasEncrypted($settings, 'bitrix24_api_key'),
-            'has_llm_api_key'         => $this->hasEncrypted($settings, 'llm_api_key'),
+            'llm_system_prompt'           => $settings?->llm_system_prompt,
+            'developer_name'              => $settings?->developer_name,
+            'developer_position'          => $settings?->developer_position,
+            'enriched_prompt_enabled'     => $settings === null ? true : $settings->enriched_prompt_enabled,
+            'sync_schedule_time'          => $settings === null ? '03:00' : $settings->sync_schedule_time,
+            'has_gitlab_token'            => $this->hasEncrypted($settings, 'gitlab_token'),
+            'has_bitrix24_api_key'        => $this->hasEncrypted($settings, 'bitrix24_api_key'),
+            'has_llm_api_key'             => $this->hasEncrypted($settings, 'llm_api_key'),
+            'bitrix24_webhook_configured' => $settings !== null
+                && $settings->bitrix24_rest_url !== null
+                && $settings->bitrix24_user_id !== null
+                && $this->hasEncrypted($settings, 'bitrix24_api_key'),
         ];
     }
 

--- a/backend/app/Http/Requests/UpdateSettingsRequest.php
+++ b/backend/app/Http/Requests/UpdateSettingsRequest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Requests;
 
 use App\Domain\Narrative\Enums\LlmProvider;
+use App\Domain\Settings\Exceptions\InvalidWebhookUrlException;
+use App\Domain\Settings\Services\WebhookUrlParser;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
@@ -25,6 +27,8 @@ class UpdateSettingsRequest extends FormRequest
             'gitlab_token'            => ['nullable', 'string'],
             'gitlab_username'         => ['nullable', 'string', 'max:255'],
             'gitlab_email'            => ['nullable', 'string', 'email', 'max:255'],
+            'bitrix24_webhook_url'    => ['nullable', 'string', 'regex:/^https?:\/\/[^\/\s]+(?::\d+)?\/rest\/\d+\/[A-Za-z0-9]+\/?$/'],
+            'bitrix24_rest_url'       => ['nullable', 'string', 'url'],
             'bitrix24_api_key'        => ['nullable', 'string'],
             'bitrix24_user_id'        => ['nullable', 'string', 'max:255'],
             'llm_provider'            => ['nullable', Rule::in(array_column(LlmProvider::cases(), 'value'))],
@@ -35,5 +39,64 @@ class UpdateSettingsRequest extends FormRequest
             'developer_position'      => ['nullable', 'string', 'max:255'],
             'sync_schedule_time'      => ['nullable', 'string', 'max:5'],
         ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'bitrix24_webhook_url.regex' => 'Webhook URL must match https://<portal>.bitrix24.ru/rest/<user_id>/<api_key>/',
+        ];
+    }
+
+    /**
+     * Strip the synthetic `bitrix24_webhook_url` from the validated payload so
+     * it never reaches `Setting::update()`/`Setting::create()` (the column does
+     * not exist on the `settings` table — only the three parsed parts do).
+     *
+     * @param  array<int, string>|int|string|null  $key
+     * @param  mixed  $default
+     */
+    public function validated($key = null, $default = null): mixed
+    {
+        /** @var array<string, mixed> $data */
+        $data = parent::validated();
+        unset($data['bitrix24_webhook_url']);
+
+        if ($key === null) {
+            return $data;
+        }
+
+        return data_get($data, $key, $default);
+    }
+
+    /**
+     * Parse the unified Bitrix24 webhook URL (if provided) into the three
+     * underlying credential columns before validation rules run.
+     *
+     * Any parsing failure is swallowed here on purpose: the `regex` rule on
+     * `bitrix24_webhook_url` will produce the user-facing 422 response.
+     */
+    protected function prepareForValidation(): void
+    {
+        $webhook = $this->input('bitrix24_webhook_url');
+
+        if (! is_string($webhook) || trim($webhook) === '') {
+            return;
+        }
+
+        try {
+            $parsed = app(WebhookUrlParser::class)->parse($webhook);
+        } catch (InvalidWebhookUrlException) {
+            return;
+        }
+
+        $this->merge([
+            'bitrix24_rest_url' => $parsed->restUrl,
+            'bitrix24_user_id'  => $parsed->userId,
+            'bitrix24_api_key'  => $parsed->apiKey,
+        ]);
     }
 }

--- a/backend/app/Infrastructure/Bitrix24/Bitrix24Client.php
+++ b/backend/app/Infrastructure/Bitrix24/Bitrix24Client.php
@@ -37,7 +37,7 @@ final class Bitrix24Client implements Bitrix24ClientInterface
         private readonly int $timeout = 30,
         private readonly int $retries = 3,
     ) {
-        $this->baseUrl = $this->stripTrailingUserId(rtrim($url, '/'));
+        $this->baseUrl = rtrim($url, '/');
     }
 
     public function getTasks(
@@ -141,6 +141,7 @@ final class Bitrix24Client implements Bitrix24ClientInterface
         } catch (ConnectionException $e) {
             Log::error('Bitrix24 API connection error', [
                 'method' => 'tasks.task.get',
+                'url'    => $this->maskedUrl('tasks.task.get'),
                 'error'  => $e->getMessage(),
             ]);
 
@@ -159,6 +160,7 @@ final class Bitrix24Client implements Bitrix24ClientInterface
         if ($response->failed()) {
             Log::error('Bitrix24 API request failed', [
                 'method' => 'tasks.task.get',
+                'url'    => $this->maskedUrl('tasks.task.get'),
                 'status' => $response->status(),
                 'body'   => $response->body(),
             ]);
@@ -186,6 +188,7 @@ final class Bitrix24Client implements Bitrix24ClientInterface
 
             Log::error('Bitrix24 API returned error', [
                 'method'      => 'tasks.task.get',
+                'url'         => $this->maskedUrl('tasks.task.get'),
                 'error'       => $data['error'],
                 'description' => $errorMessage,
             ]);
@@ -294,25 +297,40 @@ final class Bitrix24Client implements Bitrix24ClientInterface
 
     /**
      * Build the full API endpoint URL.
+     *
+     * @throws RuntimeException when any of the three URL parts is empty —
+     *                          better to fail loudly here than to send a
+     *                          malformed request to Bitrix24 (or worse, to
+     *                          a random IP like `0.0.0.250`).
      */
     private function buildUrl(string $method): string
     {
+        if ($this->baseUrl === '') {
+            throw new RuntimeException('Bitrix24 client misconfigured: baseUrl is empty');
+        }
+
+        if ($this->userId === '') {
+            throw new RuntimeException('Bitrix24 client misconfigured: userId is empty');
+        }
+
+        if ($this->apiKey === '') {
+            throw new RuntimeException('Bitrix24 client misconfigured: apiKey is empty');
+        }
+
         return sprintf('%s/%s/%s/%s.json', $this->baseUrl, $this->userId, $this->apiKey, $method);
     }
 
     /**
-     * Strip trailing user_id segment from URL if already included.
-     *
-     * Example: "https://domain.bitrix24.ru/rest/250" -> "https://domain.bitrix24.ru/rest"
+     * Build the full API endpoint URL with the api_key segment masked, so it
+     * is safe to include in log context without leaking credentials.
      */
-    private function stripTrailingUserId(string $url): string
+    private function maskedUrl(string $method): string
     {
-        $suffix = '/' . $this->userId;
-        if ($this->userId !== '' && str_ends_with($url, $suffix)) {
-            return substr($url, 0, -strlen($suffix));
-        }
+        $maskedKey = strlen($this->apiKey) >= 4
+            ? substr($this->apiKey, 0, 4) . '***'
+            : '***';
 
-        return $url;
+        return sprintf('%s/%s/%s/%s.json', $this->baseUrl, $this->userId, $maskedKey, $method);
     }
 
     /**
@@ -342,6 +360,7 @@ final class Bitrix24Client implements Bitrix24ClientInterface
         } catch (ConnectionException $e) {
             Log::error('Bitrix24 API connection error', [
                 'method' => $method,
+                'url'    => $this->maskedUrl($method),
                 'error'  => $e->getMessage(),
             ]);
 
@@ -355,6 +374,7 @@ final class Bitrix24Client implements Bitrix24ClientInterface
         if ($response->failed()) {
             Log::error('Bitrix24 API request failed', [
                 'method' => $method,
+                'url'    => $this->maskedUrl($method),
                 'status' => $response->status(),
                 'body'   => $response->body(),
             ]);
@@ -375,6 +395,7 @@ final class Bitrix24Client implements Bitrix24ClientInterface
 
             Log::error('Bitrix24 API returned error', [
                 'method'      => $method,
+                'url'         => $this->maskedUrl($method),
                 'error'       => $data['error'],
                 'description' => $errorMessage,
             ]);

--- a/backend/app/Providers/Bitrix24ServiceProvider.php
+++ b/backend/app/Providers/Bitrix24ServiceProvider.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Domain\Bitrix24\Services\Bitrix24ClientInterface;
 use App\Domain\Settings\Models\Setting;
 use App\Infrastructure\Bitrix24\Bitrix24Client;
-use App\Domain\Bitrix24\Services\Bitrix24ClientInterface;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
@@ -20,6 +20,9 @@ class Bitrix24ServiceProvider extends ServiceProvider
 
             /** @var string $url */
             $url = config('services.bitrix24.url', '');
+            if ($setting !== null && $setting->bitrix24_rest_url !== null) {
+                $url = $setting->bitrix24_rest_url;
+            }
 
             /** @var string $userId */
             $userId = config('services.bitrix24.user_id', '');

--- a/backend/database/migrations/2026_05_14_000001_add_bitrix24_rest_url_to_settings_table.php
+++ b/backend/database/migrations/2026_05_14_000001_add_bitrix24_rest_url_to_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table): void {
+            $table->string('bitrix24_rest_url')->nullable()->after('bitrix24_user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table): void {
+            $table->dropColumn('bitrix24_rest_url');
+        });
+    }
+};

--- a/backend/tests/Feature/Api/SettingsApiTest.php
+++ b/backend/tests/Feature/Api/SettingsApiTest.php
@@ -110,4 +110,115 @@ class SettingsApiTest extends TestCase
                 'has_llm_api_key'      => true,
             ]);
     }
+
+    public function test_update_settings_parses_webhook_url_and_stores_three_parts(): void
+    {
+        // GIVEN: a valid Bitrix24 webhook URL
+        $webhookUrl = 'https://example-portal.bitrix24.ru/rest/1/testwebhookkey00/';
+
+        // WHEN: PUT /api/settings with the webhook URL
+        $response = $this->putJson('/api/settings', [
+            'bitrix24_webhook_url' => $webhookUrl,
+        ]);
+
+        // THEN: response is 200 and all three credential columns are persisted
+        $response->assertOk()
+            ->assertJson(['message' => 'Settings updated']);
+
+        $this->assertDatabaseHas('settings', [
+            'bitrix24_user_id'  => '1',
+            'bitrix24_rest_url' => 'https://example-portal.bitrix24.ru/rest',
+        ]);
+
+        /** @var Setting $setting */
+        $setting = Setting::query()->first();
+        $this->assertSame('testwebhookkey00', $setting->bitrix24_api_key);
+    }
+
+    public function test_update_settings_rejects_invalid_webhook_url(): void
+    {
+        // GIVEN: a garbage webhook URL that fails regex validation
+        // WHEN: PUT /api/settings with invalid webhook URL
+        $response = $this->putJson('/api/settings', [
+            'bitrix24_webhook_url' => 'garbage',
+        ]);
+
+        // THEN: 422 Unprocessable Entity with error for the webhook field
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['bitrix24_webhook_url']);
+    }
+
+    public function test_update_settings_without_webhook_keeps_existing_credentials(): void
+    {
+        // GIVEN: a Setting already configured with Bitrix24 webhook credentials
+        Setting::factory()->create([
+            'bitrix24_rest_url' => 'https://example-portal.bitrix24.ru/rest',
+            'bitrix24_user_id'  => '1',
+            'bitrix24_api_key'  => 'testwebhookkey00',
+            'gitlab_username'   => 'old.user',
+        ]);
+
+        // WHEN: PUT /api/settings without bitrix24_webhook_url (only updating gitlab_username)
+        $response = $this->putJson('/api/settings', [
+            'gitlab_username' => 'new.user',
+        ]);
+
+        // THEN: response is 200 and webhook credentials are untouched
+        $response->assertOk();
+
+        $this->assertDatabaseHas('settings', [
+            'bitrix24_rest_url' => 'https://example-portal.bitrix24.ru/rest',
+            'bitrix24_user_id'  => '1',
+            'gitlab_username'   => 'new.user',
+        ]);
+
+        /** @var Setting $setting */
+        $setting = Setting::query()->first();
+        $this->assertSame('testwebhookkey00', $setting->bitrix24_api_key);
+    }
+
+    public function test_settings_index_returns_webhook_configured_true_when_all_parts_present(): void
+    {
+        // GIVEN: a Setting with all three webhook parts filled in
+        Setting::factory()->create([
+            'bitrix24_rest_url' => 'https://example-portal.bitrix24.ru/rest',
+            'bitrix24_user_id'  => '1',
+            'bitrix24_api_key'  => 'testwebhookkey00',
+        ]);
+
+        // WHEN: GET /api/settings
+        $response = $this->getJson('/api/settings');
+
+        // THEN: bitrix24_webhook_configured is true
+        $response->assertOk()
+            ->assertJson(['bitrix24_webhook_configured' => true]);
+    }
+
+    public function test_settings_index_returns_webhook_configured_false_when_no_setting_exists(): void
+    {
+        // GIVEN: no Setting record in the database
+        // WHEN: GET /api/settings
+        $response = $this->getJson('/api/settings');
+
+        // THEN: bitrix24_webhook_configured is false
+        $response->assertOk()
+            ->assertJson(['bitrix24_webhook_configured' => false]);
+    }
+
+    public function test_settings_index_returns_webhook_configured_false_when_rest_url_missing(): void
+    {
+        // GIVEN: a Setting with user_id and api_key but no rest_url
+        Setting::factory()->create([
+            'bitrix24_rest_url' => null,
+            'bitrix24_user_id'  => '1',
+            'bitrix24_api_key'  => 'testwebhookkey00',
+        ]);
+
+        // WHEN: GET /api/settings
+        $response = $this->getJson('/api/settings');
+
+        // THEN: bitrix24_webhook_configured is false (incomplete config)
+        $response->assertOk()
+            ->assertJson(['bitrix24_webhook_configured' => false]);
+    }
 }

--- a/backend/tests/Unit/Services/Bitrix24/Bitrix24ClientTest.php
+++ b/backend/tests/Unit/Services/Bitrix24/Bitrix24ClientTest.php
@@ -9,6 +9,7 @@ use App\Infrastructure\Bitrix24\Bitrix24Client;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -545,6 +546,91 @@ class Bitrix24ClientTest extends TestCase
         $this->expectExceptionMessage('tasks.task.get');
 
         $this->client->tryGetTask(55);
+    }
+
+    public function test_throws_when_baseurl_empty(): void
+    {
+        // GIVEN: a client constructed with an empty base URL
+        $client = new Bitrix24Client(url: '', userId: '1', apiKey: 'aaaaaaaa');
+
+        Http::fake(['*' => Http::response(['result' => ['task' => []]])]);
+
+        // WHEN / THEN: any API call throws RuntimeException mentioning misconfigured and baseUrl
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/misconfigured/i');
+        $this->expectExceptionMessageMatches('/baseUrl/i');
+
+        $client->getTask('1');
+    }
+
+    public function test_throws_when_userid_empty(): void
+    {
+        // GIVEN: a client constructed with an empty userId
+        $client = new Bitrix24Client(url: self::BASE_URL, userId: '', apiKey: 'aaaaaaaa');
+
+        Http::fake(['*' => Http::response(['result' => ['task' => []]])]);
+
+        // WHEN / THEN: any API call throws RuntimeException mentioning misconfigured and userId
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/misconfigured/i');
+        $this->expectExceptionMessageMatches('/userId/i');
+
+        $client->getTask('1');
+    }
+
+    public function test_throws_when_apikey_empty(): void
+    {
+        // GIVEN: a client constructed with an empty apiKey
+        $client = new Bitrix24Client(url: self::BASE_URL, userId: '1', apiKey: '');
+
+        Http::fake(['*' => Http::response(['result' => ['task' => []]])]);
+
+        // WHEN / THEN: any API call throws RuntimeException mentioning misconfigured and apiKey
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/misconfigured/i');
+        $this->expectExceptionMessageMatches('/apiKey/i');
+
+        $client->getTask('1');
+    }
+
+    public function test_logs_masked_url_on_http_failure(): void
+    {
+        // GIVEN: a client using a long apiKey and a 500 response
+        $apiKey = 'testwebhookkey00';
+        $client = new Bitrix24Client(
+            url: self::BASE_URL,
+            userId: self::USER_ID,
+            apiKey: $apiKey,
+        );
+
+        Http::fake(['*' => Http::response('', 500)]);
+        Log::spy();
+
+        // WHEN: getTasks triggers a 500 failure (retries exhausted)
+        try {
+            $client->getTasks('1');
+        } catch (RuntimeException) {
+            // expected — we only care about what was logged
+        }
+
+        // THEN: Log::error was called with a masked URL that contains partial key + *** but NOT the full key
+        Log::shouldHaveReceived('error')
+            ->withArgs(function (string $message, array $context) use ($apiKey): bool {
+                if (! str_contains($message, 'Bitrix24 API request failed')) {
+                    return false;
+                }
+
+                $loggedUrl = $context['url'] ?? '';
+
+                // must contain masked prefix (first 4 chars + ***)
+                $hasPrefix = str_contains((string) $loggedUrl, 'test***');
+
+                // must NOT expose the full api key
+                $hasFullKey = str_contains((string) $loggedUrl, $apiKey);
+
+                return $hasPrefix && ! $hasFullKey;
+            })
+            ->once();
     }
 
     protected function setUp(): void

--- a/backend/tests/Unit/Settings/WebhookUrlParserTest.php
+++ b/backend/tests/Unit/Settings/WebhookUrlParserTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Settings;
+
+use App\Domain\Settings\Exceptions\InvalidWebhookUrlException;
+use App\Domain\Settings\Services\WebhookUrlParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class WebhookUrlParserTest extends TestCase
+{
+    private WebhookUrlParser $parser;
+
+    public function test_parses_canonical_webhook_with_trailing_slash(): void
+    {
+        // GIVEN: a canonical webhook URL with trailing slash
+        $url = 'https://example-portal.bitrix24.ru/rest/1/testwebhookkey00/';
+
+        // WHEN: the parser processes it
+        $result = $this->parser->parse($url);
+
+        // THEN: all three parts are extracted correctly
+        $this->assertSame('https://example-portal.bitrix24.ru/rest', $result->restUrl);
+        $this->assertSame('1', $result->userId);
+        $this->assertSame('testwebhookkey00', $result->apiKey);
+    }
+
+    public function test_parses_canonical_webhook_without_trailing_slash(): void
+    {
+        // GIVEN: a canonical webhook URL without trailing slash
+        $url = 'https://example-portal.bitrix24.ru/rest/1/testwebhookkey00';
+
+        // WHEN: the parser processes it
+        $result = $this->parser->parse($url);
+
+        // THEN: all three parts are extracted correctly
+        $this->assertSame('https://example-portal.bitrix24.ru/rest', $result->restUrl);
+        $this->assertSame('1', $result->userId);
+        $this->assertSame('testwebhookkey00', $result->apiKey);
+    }
+
+    public function test_parses_http_scheme(): void
+    {
+        // GIVEN: a webhook URL using plain http (not https)
+        $url = 'http://x.bitrix24.ru/rest/1/aaaaaaaa/';
+
+        // WHEN: the parser processes it
+        $result = $this->parser->parse($url);
+
+        // THEN: restUrl preserves http scheme
+        $this->assertSame('http://x.bitrix24.ru/rest', $result->restUrl);
+        $this->assertSame('1', $result->userId);
+        $this->assertSame('aaaaaaaa', $result->apiKey);
+    }
+
+    public function test_parses_custom_port(): void
+    {
+        // GIVEN: a webhook URL with a custom port
+        $url = 'https://portal.bitrix24.ru:8443/rest/1/aaaaaaaa/';
+
+        // WHEN: the parser processes it
+        $result = $this->parser->parse($url);
+
+        // THEN: the port is included in the restUrl
+        $this->assertSame('https://portal.bitrix24.ru:8443/rest', $result->restUrl);
+        $this->assertSame('1', $result->userId);
+        $this->assertSame('aaaaaaaa', $result->apiKey);
+    }
+
+    public function test_trims_whitespace(): void
+    {
+        // GIVEN: a valid webhook URL padded with whitespace
+        $url = '  https://x.bitrix24.ru/rest/1/aaaaaaaa/  ';
+
+        // WHEN: the parser processes it
+        $result = $this->parser->parse($url);
+
+        // THEN: parsing succeeds and restUrl is clean
+        $this->assertSame('https://x.bitrix24.ru/rest', $result->restUrl);
+        $this->assertSame('1', $result->userId);
+        $this->assertSame('aaaaaaaa', $result->apiKey);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidUrlProvider(): array
+    {
+        return [
+            'empty string'          => [''],
+            'whitespace only'       => ['   '],
+            'garbage input'         => ['foo'],
+            'missing api key'       => ['https://x.bitrix24.ru/rest/250/'],
+            'missing user id'       => ['https://x.bitrix24.ru/rest/testwebhookkey00/'],
+            'non-numeric user id'   => ['https://x.bitrix24.ru/rest/abc/aaaaaaaa/'],
+            'api key too short'     => ['https://x.bitrix24.ru/rest/1/short/'],
+            'user id zero'          => ['https://x.bitrix24.ru/rest/0/aaaaaaaa/'],
+            'extra path segments'   => ['https://x.bitrix24.ru/rest/1/aaaaaaaa/extra/'],
+            'query string appended' => ['https://x.bitrix24.ru/rest/1/aaaaaaaa?foo=1'],
+        ];
+    }
+
+    #[DataProvider('invalidUrlProvider')]
+    public function test_rejects_invalid_url(string $url): void
+    {
+        // GIVEN / WHEN / THEN: invalid input always throws InvalidWebhookUrlException
+        $this->expectException(InvalidWebhookUrlException::class);
+
+        $this->parser->parse($url);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parser = new WebhookUrlParser();
+    }
+}

--- a/frontend/src/components/settings/SettingsForm.test.tsx
+++ b/frontend/src/components/settings/SettingsForm.test.tsx
@@ -106,7 +106,8 @@ describe("SettingsForm", () => {
     const user = userEvent.setup();
 
     const input = screen.getByPlaceholderText(/your-portal\.bitrix24\.ru/);
-    const webhook = "https://example-portal.bitrix24.ru/rest/1/testwebhookkey00/";
+    const webhook =
+      "https://example-portal.bitrix24.ru/rest/1/testwebhookkey00/";
     await user.type(input, webhook);
     await user.tab();
 

--- a/frontend/src/components/settings/SettingsForm.test.tsx
+++ b/frontend/src/components/settings/SettingsForm.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsForm } from "./SettingsForm";
+import type { Settings } from "../../types/api";
+
+const baseSettings: Settings = {
+  gitlab_username: "octocat",
+  gitlab_email: "octo@example.com",
+  bitrix24_user_id: null,
+  bitrix24_webhook_configured: false,
+  llm_provider: "claude",
+  llm_system_prompt: null,
+  enriched_prompt_enabled: false,
+  developer_name: "Octo Cat",
+  developer_position: "Engineer",
+  sync_schedule_time: "09:00",
+  has_gitlab_token: false,
+  has_bitrix24_api_key: false,
+  has_llm_api_key: false,
+};
+
+const renderForm = (overrides: Partial<Settings> = {}, onSubmit = vi.fn()) => {
+  const initial: Settings = { ...baseSettings, ...overrides };
+  render(
+    <SettingsForm
+      initial={initial}
+      onSubmit={onSubmit}
+      isSubmitting={false}
+      saveMessage={null}
+    />,
+  );
+  return { onSubmit };
+};
+
+describe("SettingsForm", () => {
+  it("renders webhook URL input and hides legacy fields", () => {
+    renderForm();
+
+    expect(screen.queryByText("Bitrix24 API Key")).not.toBeInTheDocument();
+    expect(screen.queryByText("Bitrix24 User ID")).not.toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/your-portal\.bitrix24\.ru/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows configured indicator when bitrix24_webhook_configured is true", () => {
+    renderForm({ bitrix24_webhook_configured: true });
+
+    const webhookLabel = screen.getByText(/Bitrix24 Webhook URL/);
+    expect(webhookLabel).toHaveTextContent("[Настроен]");
+  });
+
+  it("shows not configured indicator when bitrix24_webhook_configured is false", () => {
+    renderForm({ bitrix24_webhook_configured: false });
+
+    const webhookLabel = screen.getByText(/Bitrix24 Webhook URL/);
+    expect(webhookLabel).toHaveTextContent("[Не настроен]");
+  });
+
+  it("shows inline error on blur with invalid url", async () => {
+    renderForm();
+    const user = userEvent.setup();
+
+    const input = screen.getByPlaceholderText(/your-portal\.bitrix24\.ru/);
+    await user.type(input, "foo");
+    await user.tab();
+
+    expect(
+      screen.getByText(
+        "Формат: https://<портал>.bitrix24.ru/rest/<user_id>/<api_key>/",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show error for empty input on blur", async () => {
+    renderForm();
+    const user = userEvent.setup();
+
+    const input = screen.getByPlaceholderText(/your-portal\.bitrix24\.ru/);
+    await user.click(input);
+    await user.tab();
+
+    expect(
+      screen.queryByText(
+        "Формат: https://<портал>.bitrix24.ru/rest/<user_id>/<api_key>/",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("blocks submit while error is present", async () => {
+    const { onSubmit } = renderForm();
+    const user = userEvent.setup();
+
+    const input = screen.getByPlaceholderText(/your-portal\.bitrix24\.ru/);
+    await user.type(input, "not-a-url");
+    await user.tab();
+
+    await user.click(screen.getByRole("button", { name: "Сохранить" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits canonical webhook url", async () => {
+    const { onSubmit } = renderForm();
+    const user = userEvent.setup();
+
+    const input = screen.getByPlaceholderText(/your-portal\.bitrix24\.ru/);
+    const webhook = "https://example-portal.bitrix24.ru/rest/1/testwebhookkey00/";
+    await user.type(input, webhook);
+    await user.tab();
+
+    await user.click(screen.getByRole("button", { name: "Сохранить" }));
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ bitrix24_webhook_url: webhook }),
+    );
+  });
+
+  it("omits empty webhook from payload", async () => {
+    const { onSubmit } = renderForm();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Сохранить" }));
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    const payload = onSubmit.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("bitrix24_webhook_url");
+  });
+});

--- a/frontend/src/components/settings/SettingsForm.tsx
+++ b/frontend/src/components/settings/SettingsForm.tsx
@@ -8,11 +8,17 @@ interface SettingsFormProps {
   saveMessage: string | null;
 }
 
+const WEBHOOK_URL_REGEX =
+  /^https?:\/\/[^/\s]+(?::\d+)?\/rest\/\d+\/[A-Za-z0-9]+\/?$/;
+
+const WEBHOOK_ERROR_MESSAGE =
+  "Формат: https://<портал>.bitrix24.ru/rest/<user_id>/<api_key>/";
+
 function buildInitialForm(settings: Settings): SettingsInput {
   return {
     gitlab_username: settings.gitlab_username ?? "",
     gitlab_email: settings.gitlab_email ?? "",
-    bitrix24_user_id: settings.bitrix24_user_id ?? "",
+    bitrix24_webhook_url: "",
     llm_provider: settings.llm_provider,
     llm_system_prompt: settings.llm_system_prompt ?? "",
     enriched_prompt_enabled: settings.enriched_prompt_enabled,
@@ -31,17 +37,34 @@ export function SettingsForm({
   const [form, setForm] = useState<SettingsInput>(() =>
     buildInitialForm(initial),
   );
+  const [webhookError, setWebhookError] = useState<string | null>(null);
 
   const handleChange = (field: keyof SettingsInput, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
   };
 
+  const handleWebhookBlur = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      setWebhookError(null);
+      return;
+    }
+    if (!WEBHOOK_URL_REGEX.test(trimmed)) {
+      setWebhookError(WEBHOOK_ERROR_MESSAGE);
+      return;
+    }
+    setWebhookError(null);
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (webhookError !== null) {
+      return;
+    }
     // Only send non-empty password fields
     const payload: SettingsInput = { ...form };
     if (!payload.gitlab_token) delete payload.gitlab_token;
-    if (!payload.bitrix24_api_key) delete payload.bitrix24_api_key;
+    if (!payload.bitrix24_webhook_url) delete payload.bitrix24_webhook_url;
     if (!payload.llm_api_key) delete payload.llm_api_key;
     onSubmit(payload);
   };
@@ -143,33 +166,50 @@ export function SettingsForm({
 
       <div style={fieldStyle}>
         <label style={labelStyle}>
-          Bitrix24 API Key{" "}
+          Bitrix24 Webhook URL{" "}
           <span
             style={{
-              color: statusColor(initial.has_bitrix24_api_key),
+              color: statusColor(initial.bitrix24_webhook_configured),
               fontWeight: "normal",
             }}
           >
-            {statusText(initial.has_bitrix24_api_key)}
+            {statusText(initial.bitrix24_webhook_configured)}
           </span>
         </label>
+        <div
+          style={{
+            marginTop: "-4px",
+            marginBottom: "8px",
+            fontSize: "12px",
+            color: "rgba(255, 255, 255, 0.5)",
+          }}
+        >
+          Полный webhook URL (Bitrix24 &rarr; Разработчикам &rarr; Другое &rarr;
+          Входящий вебхук). Формат:
+          https://&lt;портал&gt;.bitrix24.ru/rest/&lt;user_id&gt;/&lt;api_key&gt;/
+        </div>
         <input
           type="password"
-          placeholder="Введите новый ключ для обновления"
-          value={form.bitrix24_api_key ?? ""}
-          onChange={(e) => handleChange("bitrix24_api_key", e.target.value)}
-          style={inputStyle}
+          placeholder="https://your-portal.bitrix24.ru/rest/123/abc.../"
+          value={form.bitrix24_webhook_url ?? ""}
+          onChange={(e) => handleChange("bitrix24_webhook_url", e.target.value)}
+          onBlur={(e) => handleWebhookBlur(e.target.value)}
+          style={{
+            ...inputStyle,
+            border: webhookError ? "1px solid #e53e3e" : "1px solid #444",
+          }}
         />
-      </div>
-
-      <div style={fieldStyle}>
-        <label style={labelStyle}>Bitrix24 User ID</label>
-        <input
-          type="text"
-          value={form.bitrix24_user_id ?? ""}
-          onChange={(e) => handleChange("bitrix24_user_id", e.target.value)}
-          style={inputStyle}
-        />
+        {webhookError && (
+          <div
+            style={{
+              marginTop: "6px",
+              fontSize: "12px",
+              color: "#e53e3e",
+            }}
+          >
+            {webhookError}
+          </div>
+        )}
       </div>
 
       <div style={fieldStyle}>
@@ -347,14 +387,16 @@ export function SettingsForm({
       >
         <button
           type="submit"
-          disabled={isSubmitting}
+          disabled={isSubmitting || webhookError !== null}
           style={{
             padding: "10px 24px",
-            background: isSubmitting ? "#999" : "#646cff",
+            background:
+              isSubmitting || webhookError !== null ? "#999" : "#646cff",
             color: "#fff",
             border: "none",
             borderRadius: "6px",
-            cursor: isSubmitting ? "not-allowed" : "pointer",
+            cursor:
+              isSubmitting || webhookError !== null ? "not-allowed" : "pointer",
             fontSize: "15px",
           }}
         >

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -12,6 +12,7 @@ export interface Settings {
   gitlab_username: string | null;
   gitlab_email: string | null;
   bitrix24_user_id: string | null;
+  bitrix24_webhook_configured: boolean;
   llm_provider: string;
   llm_system_prompt: string | null;
   enriched_prompt_enabled: boolean;
@@ -27,8 +28,7 @@ export interface SettingsInput {
   gitlab_token?: string;
   gitlab_username?: string;
   gitlab_email?: string;
-  bitrix24_api_key?: string;
-  bitrix24_user_id?: string;
+  bitrix24_webhook_url?: string;
   llm_provider?: string;
   llm_api_key?: string;
   llm_system_prompt?: string;


### PR DESCRIPTION
Closes #117

## Summary

Bitrix24 sync was failing with `cURL 7` (host parsed from a credential fragment) and HTTP `404` from nginx because `BITRIX24_URL`, `settings.bitrix24_user_id` and `settings.bitrix24_api_key` were three independent inputs without format validation. Pasting the full webhook into the wrong admin field was enough to break sync — see linked issue for the failure modes.

This PR collapses the three fields into a single "Bitrix24 Webhook URL" admin input, parses it server-side into the three parts on save, and hardens the client so misconfiguration fails fast with a useful message instead of confusing cURL errors.

## Changes

- **Parser**: new `App\Domain\Settings\Services\WebhookUrlParser` + `ParsedWebhook` DTO + `InvalidWebhookUrlException`. Validates the canonical shape `https://<portal>/rest/<user_id>/<api_key>/` (http/https, optional port, optional trailing slash, numeric user id, api key ≥ 8 alphanumeric chars).
- **Storage**: new nullable column `settings.bitrix24_rest_url` so the REST host is no longer `.env`-only. User id and (encrypted) api key continue to live in their existing columns.
- **API**: `UpdateSettingsRequest::prepareForValidation()` parses `bitrix24_webhook_url` and merges the three parts into the payload. A regex `rules()` entry and a `messages()` override give a clean 422 with a clear message for malformed input. The synthetic `bitrix24_webhook_url` field is stripped from `validated()` so it doesn't leak into the model.
- **Provider**: `Bitrix24ServiceProvider` reads all three parts uniformly from the `Setting` row, with `.env` values (`BITRIX24_URL`, `BITRIX24_USER_ID`, `BITRIX24_API_KEY`) as fallback for dev / first run. `DecryptException` around the api key is preserved.
- **Client**: `Bitrix24Client` drops the brittle `stripTrailingUserId()` helper, fails fast with a `RuntimeException` when any URL part is empty, and logs a masked URL (api key → first 4 chars + `***`) on every error path. No more `0.0.0.<digits>` in the log.
- **Admin UI**: `SettingsForm.tsx` replaces the API Key + User ID inputs with one password-masked "Bitrix24 Webhook URL" field. Includes an on-blur regex check matching the backend rule, an inline error message, a "Configured / Not configured" badge driven by the new `bitrix24_webhook_configured` flag, and a submit guard while the error is present.
- **Controller**: `SettingsController::toResponseData()` exposes `bitrix24_webhook_configured`; the webhook URL itself is never returned.

## Tests

- `tests/Unit/Settings/WebhookUrlParserTest.php` — 15 cases: canonical with/without trailing slash, http/https, custom port, whitespace trim, plus rejection of empty / garbage / missing api key / missing user id / non-numeric user id / short api key / zero user id / extra segments / query string.
- `tests/Feature/Api/SettingsApiTest.php` — webhook is parsed and stored across three columns; malformed URL returns 422; empty payload preserves existing credentials; `index` returns the `bitrix24_webhook_configured` flag.
- `tests/Unit/Services/Bitrix24/Bitrix24ClientTest.php` — fails fast when any of `baseUrl` / `userId` / `apiKey` is empty; error logs contain a masked URL (`.../rest/<user_id>/<first4>***/...`) and never leak the full key.
- `frontend/src/components/settings/SettingsForm.test.tsx` — renders the new field, hides legacy inputs, shows / hides the configured badge, surfaces an inline error on invalid blur, blocks submit on error, submits a canonical webhook URL, omits an empty webhook from the payload.

PHPUnit: 387 passed (+25 new). Vitest: 16 passed (+8 new). Pint, PHPStan, ESLint, `tsc --noEmit`, `npm run build` — all clean inside the Docker Node 22 environment.

## Test plan

- [ ] `docker compose exec app php artisan migrate` applies the new migration cleanly.
- [ ] In admin settings, paste a valid webhook → save → badge flips to "Configured".
- [ ] `docker compose exec app php artisan sync:run` against the configured webhook produces no `cURL 7` or `404` entries in `storage/logs/laravel.log`.
- [ ] Force an API failure (e.g. revoke the key in Bitrix24) → log entry contains a masked URL with `<first4>***` and never the full secret.
- [ ] Paste a malformed URL into the admin form → inline error appears on blur, submit is blocked; bypassing the UI returns 422 from the API.
- [ ] Save the form without changing the webhook field → existing credentials are preserved.
- [ ] Clear the `settings` row (`php artisan settings:reset` + manual `bitrix24_*` reset) → sync still works using `.env` values.

## Migration / rollback notes

- Migration is additive (one nullable column). `down()` drops the column. No data loss on rollback, but UIs built against this branch will see `bitrix24_webhook_configured: false` and require reconfiguring after rollback.
- Existing operators with credentials only in `.env` are not affected — fallback path is preserved.