### PR TITLE
fix(ui): restore card header contrast via dedicated foreground token (#29)

### DIFF
--- a/frontend/src/components/inbox/InboxCard.tsx
+++ b/frontend/src/components/inbox/InboxCard.tsx
@@ -39,7 +39,8 @@ export function InboxCard({
         borderRadius: "8px",
         padding: "16px",
         marginBottom: "12px",
-        background: "#fff",
+        background: "var(--card-bg)",
+        color: "var(--card-fg)",
       }}
     >
       <div

--- a/frontend/src/components/report/ReportDaysTab.tsx
+++ b/frontend/src/components/report/ReportDaysTab.tsx
@@ -91,7 +91,8 @@ export function ReportDaysTab({ reportId, days }: Props) {
         <div
           key={day.date}
           style={{
-            background: "#f9f9f9",
+            background: "var(--card-bg)",
+            color: "var(--card-fg)",
             borderRadius: "8px",
             padding: "20px",
             marginBottom: "16px",

--- a/frontend/src/components/report/ReportTasksTab.tsx
+++ b/frontend/src/components/report/ReportTasksTab.tsx
@@ -94,7 +94,8 @@ export function ReportTasksTab({ reportId, tasks }: Props) {
             <div
               key={task.id}
               style={{
-                background: "#f9f9f9",
+                background: "var(--card-bg)",
+                color: "var(--card-fg)",
                 borderRadius: "8px",
                 padding: "16px 20px",
                 marginBottom: "12px",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,6 +6,8 @@
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
+  --card-bg: #f9f9f9;
+  --card-fg: #213547;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,7 +10,8 @@ export function DashboardPage() {
 
       <section
         style={{
-          background: "#f9f9f9",
+          background: "var(--card-bg)",
+          color: "var(--card-fg)",
           borderRadius: "8px",
           padding: "20px",
           marginBottom: "24px",

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -142,7 +142,8 @@ export function ReportPage() {
         <div
           style={{
             maxWidth: "600px",
-            background: "#f9f9f9",
+            background: "var(--card-bg)",
+            color: "var(--card-fg)",
             padding: "24px",
             borderRadius: "8px",
           }}


### PR DESCRIPTION
## Summary

Closes #29.

Section headers inside light-surface cards (e.g. "Синхронизация" on the dashboard) rendered as white-on-light and were nearly invisible in dark color-scheme.

Root cause: `:root` in `index.css` sets `color: rgba(255, 255, 255, 0.87)` for the default dark color-scheme, but card containers across the app hard-code a light `background` (`#f9f9f9` / `#fff`) without pairing it with a foreground color. Headings inside inherited the page-level white color and blended with the card.

## Fix

- `frontend/src/index.css` — add two CSS custom properties to `:root`:
  - `--card-bg: #f9f9f9`
  - `--card-fg: #213547`
- 5 card surfaces now apply both `background: var(--card-bg)` and `color: var(--card-fg)`, so children inherit a readable foreground without per-element overrides:
  - `frontend/src/pages/DashboardPage.tsx` (Sync section)
  - `frontend/src/pages/ReportPage.tsx` (report-generation form)
  - `frontend/src/components/inbox/InboxCard.tsx`
  - `frontend/src/components/report/ReportDaysTab.tsx`
  - `frontend/src/components/report/ReportTasksTab.tsx`

`SettingsForm.tsx` is intentionally left untouched (already-correct dark card surface).

## Out of scope

- No shared `<Card>` component / broader inline-style refactor.
- No changes to dark/light-mode toggle behaviour.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean (Vite 8 on Node 22)
- [x] Browser, **dark** `prefers-color-scheme` (matches the issue screenshot):
  - "Синхронизация" h2 computed `color = rgb(33, 53, 71)` on card `rgb(249, 249, 249)` — contrast ≈12.6:1 (WCAG AAA).
  - "Панель управления" h1 (outside card) stays white on dark page background — no regression.
- [x] Browser, **light** `prefers-color-scheme` — cards still readable; no regression on dashboard / inbox / report tabs / report-generation form.
- [x] Settings page (dark card) unchanged.