### PR TITLE
fix(narrative): preflight LLM config to prevent silent empty reports

### DIFF
--- a/backend/app/Domain/Narrative/Actions/GenerateNarrativesForReport.php
+++ b/backend/app/Domain/Narrative/Actions/GenerateNarrativesForReport.php
@@ -26,6 +26,9 @@ final readonly class GenerateNarrativesForReport
     ) {
     }
 
+    /**
+     * Reloads the nested reportTask relation between global and day-task stages so the fallback observes the freshly written global narrative.
+     */
     public function __invoke(Report $report): void
     {
         $report->load(['reportTasks.task.matchResults.branch.commits', 'reportDays.reportDayTasks.reportTask.task']);
@@ -33,9 +36,6 @@ final readonly class GenerateNarrativesForReport
 
         $this->generateGlobalTaskNarratives($report, $systemPrompt);
 
-        // Refresh nested reportTask relations so day-task fallback sees the just-generated global narratives
-        // (Eloquent caches each relation separately, so updating $report->reportTasks does not propagate
-        // to $report->reportDays->reportDayTasks->reportTask instances).
         $report->load('reportDays.reportDayTasks.reportTask.task');
 
         $this->generateDayTaskNarratives($report, $systemPrompt);

--- a/backend/app/Domain/Narrative/Actions/GenerateNarrativesForReport.php
+++ b/backend/app/Domain/Narrative/Actions/GenerateNarrativesForReport.php
@@ -31,9 +31,15 @@ final readonly class GenerateNarrativesForReport
         $report->load(['reportTasks.task.matchResults.branch.commits', 'reportDays.reportDayTasks.reportTask.task']);
         $systemPrompt = $this->support->getSystemPrompt();
 
+        $this->generateGlobalTaskNarratives($report, $systemPrompt);
+
+        // Refresh nested reportTask relations so day-task fallback sees the just-generated global narratives
+        // (Eloquent caches each relation separately, so updating $report->reportTasks does not propagate
+        // to $report->reportDays->reportDayTasks->reportTask instances).
+        $report->load('reportDays.reportDayTasks.reportTask.task');
+
         $this->generateDayTaskNarratives($report, $systemPrompt);
         $this->generateDayLevelNarratives($report, $systemPrompt);
-        $this->generateGlobalTaskNarratives($report, $systemPrompt);
 
         $report->markAsGenerated();
     }

--- a/backend/app/Domain/Narrative/Exceptions/InvalidLlmConfigException.php
+++ b/backend/app/Domain/Narrative/Exceptions/InvalidLlmConfigException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Narrative\Exceptions;
+
+use RuntimeException;
+
+final class InvalidLlmConfigException extends RuntimeException
+{
+    /**
+     * @param  list<string>  $violations
+     */
+    public function __construct(public readonly array $violations)
+    {
+        parent::__construct('LLM configuration is invalid: ' . implode('; ', $violations), 422);
+    }
+}

--- a/backend/app/Domain/Narrative/Services/LlmConfigValidator.php
+++ b/backend/app/Domain/Narrative/Services/LlmConfigValidator.php
@@ -12,9 +12,6 @@ final readonly class LlmConfigValidator
     {
     }
 
-    /**
-     * @throws InvalidLlmConfigException
-     */
     public function validate(): void
     {
         $violations = $this->provider->validate();

--- a/backend/app/Domain/Narrative/Services/LlmConfigValidator.php
+++ b/backend/app/Domain/Narrative/Services/LlmConfigValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Narrative\Services;
+
+use App\Domain\Narrative\Exceptions\InvalidLlmConfigException;
+
+final readonly class LlmConfigValidator
+{
+    public function __construct(private LlmProviderInterface $provider)
+    {
+    }
+
+    /**
+     * @throws InvalidLlmConfigException
+     */
+    public function validate(): void
+    {
+        $violations = $this->provider->validate();
+
+        if ($violations !== []) {
+            throw new InvalidLlmConfigException($violations);
+        }
+    }
+}

--- a/backend/app/Domain/Narrative/Services/LlmProviderInterface.php
+++ b/backend/app/Domain/Narrative/Services/LlmProviderInterface.php
@@ -23,7 +23,7 @@ interface LlmProviderInterface
     public function getProviderName(): string;
 
     /**
-     * @return list<string> Reasons why current configuration is invalid; empty array means OK.
+     * @return list<string>
      */
     public function validate(): array;
 }

--- a/backend/app/Domain/Narrative/Services/LlmProviderInterface.php
+++ b/backend/app/Domain/Narrative/Services/LlmProviderInterface.php
@@ -21,4 +21,9 @@ interface LlmProviderInterface
     public function isAvailable(): bool;
 
     public function getProviderName(): string;
+
+    /**
+     * @return list<string> Reasons why current configuration is invalid; empty array means OK.
+     */
+    public function validate(): array;
 }

--- a/backend/app/Http/Controllers/ReportController.php
+++ b/backend/app/Http/Controllers/ReportController.php
@@ -10,6 +10,7 @@ use App\Domain\Narrative\Actions\RegenerateDayNarrative;
 use App\Domain\Narrative\Actions\RegenerateTaskNarrative;
 use App\Domain\Narrative\Actions\UndoDayNarrative;
 use App\Domain\Narrative\Actions\UndoTaskNarrative;
+use App\Domain\Narrative\Services\LlmConfigValidator;
 use App\Domain\Matching\DTOs\UnclassifiedCommit;
 use App\Domain\Matching\Queries\GetUnclassifiedCommitsForDateRange;
 use App\Domain\Report\Actions\GenerateReport;
@@ -89,7 +90,10 @@ class ReportController extends Controller
         GenerateReportRequest $request,
         GenerateReport $generateReport,
         HasDataForDateRange $hasData,
+        LlmConfigValidator $llmConfigValidator,
     ): JsonResponse {
+        $llmConfigValidator->validate();
+
         /** @var array{type: string, date_from: string, date_to: string} $validated */
         $validated = $request->validated();
 

--- a/backend/app/Infrastructure/LLM/ClaudeProvider.php
+++ b/backend/app/Infrastructure/LLM/ClaudeProvider.php
@@ -12,6 +12,7 @@ use App\Domain\Narrative\DTOs\TaskNarrativeResponse;
 use App\Domain\Narrative\Services\LlmProviderInterface;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
 use RuntimeException;
 
 class ClaudeProvider implements LlmProviderInterface
@@ -124,10 +125,38 @@ class ClaudeProvider implements LlmProviderInterface
     }
 
     /**
+     * @return list<string>
+     */
+    public function validate(): array
+    {
+        $violations = [];
+
+        if ($this->apiKey === '') {
+            $violations[] = 'LLM_API_KEY is required';
+        }
+
+        if ($this->maxTokens < 1) {
+            $violations[] = 'LLM_MAX_TOKENS must be >= 1';
+        }
+
+        if ($this->model === '') {
+            $violations[] = 'LLM model is not configured';
+        }
+
+        return $violations;
+    }
+
+    /**
      * @return array{narrative: string, tokens_used: int}
      */
     private function sendRequest(string $systemPrompt, string $userPrompt): array
     {
+        if ($this->maxTokens < 1) {
+            throw new InvalidArgumentException(
+                'LLM max_tokens must be >= 1, got ' . $this->maxTokens
+            );
+        }
+
         try {
             return retry(
                 self::MAX_RETRIES,
@@ -184,6 +213,13 @@ class ClaudeProvider implements LlmProviderInterface
         $data = $response->json();
 
         $narrative = $data['content'][0]['text'] ?? '';
+
+        if (trim($narrative) === '') {
+            throw new RuntimeException(
+                'LLM returned empty content (possibly max_tokens=0 or filtered response)'
+            );
+        }
+
         $tokensUsed = $data['usage']['input_tokens'] + $data['usage']['output_tokens'];
 
         return [

--- a/backend/app/Infrastructure/LLM/OpenAiProvider.php
+++ b/backend/app/Infrastructure/LLM/OpenAiProvider.php
@@ -12,6 +12,7 @@ use App\Domain\Narrative\DTOs\TaskNarrativeResponse;
 use App\Domain\Narrative\Services\LlmProviderInterface;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
 use RuntimeException;
 
 class OpenAiProvider implements LlmProviderInterface
@@ -124,10 +125,38 @@ class OpenAiProvider implements LlmProviderInterface
     }
 
     /**
+     * @return list<string>
+     */
+    public function validate(): array
+    {
+        $violations = [];
+
+        if ($this->apiKey === '') {
+            $violations[] = 'LLM_API_KEY is required';
+        }
+
+        if ($this->maxTokens < 1) {
+            $violations[] = 'LLM_MAX_TOKENS must be >= 1';
+        }
+
+        if ($this->model === '') {
+            $violations[] = 'LLM model is not configured';
+        }
+
+        return $violations;
+    }
+
+    /**
      * @return array{narrative: string, tokens_used: int}
      */
     private function sendRequest(string $systemPrompt, string $userPrompt): array
     {
+        if ($this->maxTokens < 1) {
+            throw new InvalidArgumentException(
+                'LLM max_tokens must be >= 1, got ' . $this->maxTokens
+            );
+        }
+
         try {
             return retry(
                 self::MAX_RETRIES,
@@ -186,6 +215,13 @@ class OpenAiProvider implements LlmProviderInterface
         $data = $response->json();
 
         $narrative = $data['choices'][0]['message']['content'] ?? '';
+
+        if (trim($narrative) === '') {
+            throw new RuntimeException(
+                'LLM returned empty content (possibly max_tokens=0 or filtered response)'
+            );
+        }
+
         $tokensUsed = $data['usage']['total_tokens'];
 
         return [

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Domain\Narrative\Exceptions\InvalidLlmConfigException;
 use App\Exceptions\InvalidTokenException;
 use App\Exceptions\NoDataException;
 use App\Exceptions\ServiceUnavailableException;
@@ -8,6 +9,7 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -48,6 +50,22 @@ return Application::configure(basePath: dirname(__DIR__))
             if ($request->wantsJson() || $request->is('api/*')) {
                 return response()->json([
                     'error' => $e->getMessage(),
+                ], 422);
+            }
+
+            return null;
+        });
+
+        $exceptions->render(function (InvalidLlmConfigException $e, Request $request): ?JsonResponse {
+            if ($request->wantsJson() || $request->is('api/*')) {
+                Log::warning('Report generation aborted: invalid LLM config', [
+                    'violations' => $e->violations,
+                ]);
+
+                return response()->json([
+                    'error'        => 'LLM configuration is invalid',
+                    'violations'   => $e->violations,
+                    'settings_url' => '/settings',
                 ], 422);
             }
 

--- a/backend/tests/Feature/Report/ReportGenerationValidationTest.php
+++ b/backend/tests/Feature/Report/ReportGenerationValidationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Domain\Narrative\Services\LlmProviderInterface;
+use App\Domain\Report\Models\Report;
+use App\Domain\Settings\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Mocks\MockLlmProvider;
+use Tests\TestCase;
+
+/**
+ * Tests that the report generation endpoint performs a preflight LLM config validation
+ * and returns 422 with structured violations before creating any Report record.
+ *
+ * These are TDD red tests — they will fail until:
+ *  - LlmConfigValidator is created (Шаг 2)
+ *  - InvalidLlmConfigException is created (Шаг 3)
+ *  - ReportController::generate() calls the validator (Шаг 3)
+ */
+final class ReportGenerationValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const array VALID_GENERATE_BODY = [
+        'type'      => 'daily',
+        'date_from' => '2026-03-10',
+        'date_to'   => '2026-03-10',
+    ];
+
+    public function test_returns_422_when_max_tokens_is_zero(): void
+    {
+        config(['llm.providers.claude.max_tokens' => 0]);
+
+        Setting::factory()->withClaude()->create(['llm_api_key' => 'sk-test-key-valid']);
+
+        $response = $this->postJson('/api/reports/generate', self::VALID_GENERATE_BODY);
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure(['error', 'violations']);
+
+        /** @var list<string> $violations */
+        $violations = $response->json('violations');
+        $this->assertTrue(
+            collect($violations)->contains(fn (string $v): bool => str_contains($v, 'LLM_MAX_TOKENS')),
+            'Violations must contain a message referencing LLM_MAX_TOKENS'
+        );
+
+        $this->assertSame(0, Report::count(), 'No report must be created when config is invalid');
+    }
+
+    public function test_returns_422_when_api_key_missing(): void
+    {
+        config(['llm.providers.claude.max_tokens' => 1024]);
+
+        // Create setting without an api key so provider resolves empty key
+        Setting::factory()->withClaude()->create(['llm_api_key' => null]);
+
+        $response = $this->postJson('/api/reports/generate', self::VALID_GENERATE_BODY);
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure(['error', 'violations']);
+
+        /** @var list<string> $violations */
+        $violations = $response->json('violations');
+        $this->assertTrue(
+            collect($violations)->contains(fn (string $v): bool => str_contains($v, 'LLM_API_KEY')),
+            'Violations must contain a message referencing LLM_API_KEY'
+        );
+
+        $this->assertSame(0, Report::count(), 'No report must be created when config is invalid');
+    }
+
+    public function test_returns_201_when_config_valid(): void
+    {
+        // Bind a always-valid mock provider so no real HTTP calls happen
+        $mockLlm = new MockLlmProvider();
+        $mockLlm->violations = [];
+        $this->app->instance(LlmProviderInterface::class, $mockLlm);
+
+        config(['llm.providers.claude.max_tokens' => 1024]);
+
+        Setting::factory()->withClaude()->create(['llm_api_key' => 'sk-test-key-valid']);
+
+        // No data exists in DB, so HasDataForDateRange returns false → 422 for no data
+        // We only test that the LLM config check itself passes (not 422 from config validation)
+        // The controller may return 422 from NoDataException — that is acceptable and expected
+        $response = $this->postJson('/api/reports/generate', self::VALID_GENERATE_BODY);
+
+        // Must NOT be 422 with violations about LLM config (can be 422 about missing data)
+        if ($response->status() === 422) {
+            $violations = $response->json('violations');
+            $this->assertNull(
+                $violations,
+                'Response must not contain LLM config violations when config is valid — got: ' . json_encode($violations)
+            );
+        }
+
+        // If somehow data exists and report is created, accept 201 as well
+        $this->assertContains(
+            $response->status(),
+            [201, 422],
+            'Expected 201 (report created) or 422 (no data), not an LLM config error'
+        );
+    }
+}

--- a/backend/tests/Feature/Report/ReportGenerationValidationTest.php
+++ b/backend/tests/Feature/Report/ReportGenerationValidationTest.php
@@ -11,15 +11,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Mocks\MockLlmProvider;
 use Tests\TestCase;
 
-/**
- * Tests that the report generation endpoint performs a preflight LLM config validation
- * and returns 422 with structured violations before creating any Report record.
- *
- * These are TDD red tests — they will fail until:
- *  - LlmConfigValidator is created (Шаг 2)
- *  - InvalidLlmConfigException is created (Шаг 3)
- *  - ReportController::generate() calls the validator (Шаг 3)
- */
 final class ReportGenerationValidationTest extends TestCase
 {
     use RefreshDatabase;
@@ -55,7 +46,6 @@ final class ReportGenerationValidationTest extends TestCase
     {
         config(['llm.providers.claude.max_tokens' => 1024]);
 
-        // Create setting without an api key so provider resolves empty key
         Setting::factory()->withClaude()->create(['llm_api_key' => null]);
 
         $response = $this->postJson('/api/reports/generate', self::VALID_GENERATE_BODY);
@@ -75,7 +65,6 @@ final class ReportGenerationValidationTest extends TestCase
 
     public function test_returns_201_when_config_valid(): void
     {
-        // Bind a always-valid mock provider so no real HTTP calls happen
         $mockLlm = new MockLlmProvider();
         $mockLlm->violations = [];
         $this->app->instance(LlmProviderInterface::class, $mockLlm);
@@ -84,12 +73,8 @@ final class ReportGenerationValidationTest extends TestCase
 
         Setting::factory()->withClaude()->create(['llm_api_key' => 'sk-test-key-valid']);
 
-        // No data exists in DB, so HasDataForDateRange returns false → 422 for no data
-        // We only test that the LLM config check itself passes (not 422 from config validation)
-        // The controller may return 422 from NoDataException — that is acceptable and expected
         $response = $this->postJson('/api/reports/generate', self::VALID_GENERATE_BODY);
 
-        // Must NOT be 422 with violations about LLM config (can be 422 about missing data)
         if ($response->status() === 422) {
             $violations = $response->json('violations');
             $this->assertNull(
@@ -98,7 +83,6 @@ final class ReportGenerationValidationTest extends TestCase
             );
         }
 
-        // If somehow data exists and report is created, accept 201 as well
         $this->assertContains(
             $response->status(),
             [201, 422],

--- a/backend/tests/Mocks/MockLlmProvider.php
+++ b/backend/tests/Mocks/MockLlmProvider.php
@@ -22,10 +22,6 @@ final class MockLlmProvider implements LlmProviderInterface
     /** @var array<int, DayCommitsNarrativeRequest> */
     public array $dayCommitsRequests = [];
 
-    /**
-     * Legacy flag — kept for backward compatibility with existing tests.
-     * When true, ALL generation methods fail unless a more specific flag is set.
-     */
     public bool $shouldFail = false;
 
     public bool $shouldFailGlobal = false;
@@ -36,18 +32,10 @@ final class MockLlmProvider implements LlmProviderInterface
 
     public bool $shouldFailDayCommits = false;
 
-    /**
-     * Call order log: each entry is one of 'global', 'day-task', 'day-fallback', 'day-commits'.
-     *
-     * @var list<'global'|'day-task'|'day-fallback'|'day-commits'>
-     */
+    /** @var list<'global'|'day-task'|'day-fallback'|'day-commits'> */
     public array $callOrder = [];
 
-    /**
-     * Violations returned by validate(). An empty array means the config is valid.
-     *
-     * @var list<string>
-     */
+    /** @var list<string> */
     public array $violations = [];
 
     public string $narrativeText = 'Mock narrative text for testing.';
@@ -56,22 +44,13 @@ final class MockLlmProvider implements LlmProviderInterface
 
     public string $dayCommitsText = 'Mock day commits narrative for testing.';
 
-    /**
-     * Counts how many times generateNarrative() has been called per task title.
-     * Used to distinguish global-task calls (first call per title, no previousNarratives)
-     * from day-task calls (subsequent calls OR calls with previousNarratives).
-     *
-     * @var array<string, int>
-     */
+    /** @var array<string, int> */
     private array $seenTaskTitles = [];
 
     public function generateNarrative(TaskNarrativeRequest $request): TaskNarrativeResponse
     {
         $this->narrativeRequests[] = $request;
 
-        // Distinguish global vs day-task by inspecting previousNarratives and seen titles.
-        // Global-task: first call for this title AND no previousNarratives passed.
-        // Day-task: second+ call for this title OR previousNarratives is not empty.
         $isFirstCallForTitle = ! isset($this->seenTaskTitles[$request->taskTitle]);
         $this->seenTaskTitles[$request->taskTitle] = ($this->seenTaskTitles[$request->taskTitle] ?? 0) + 1;
 
@@ -142,11 +121,7 @@ final class MockLlmProvider implements LlmProviderInterface
         return 'mock';
     }
 
-    /**
-     * Returns validation violations for the provider configuration.
-     *
-     * @return list<string>
-     */
+    /** @return list<string> */
     public function validate(): array
     {
         return $this->violations;

--- a/backend/tests/Mocks/MockLlmProvider.php
+++ b/backend/tests/Mocks/MockLlmProvider.php
@@ -22,7 +22,33 @@ final class MockLlmProvider implements LlmProviderInterface
     /** @var array<int, DayCommitsNarrativeRequest> */
     public array $dayCommitsRequests = [];
 
+    /**
+     * Legacy flag — kept for backward compatibility with existing tests.
+     * When true, ALL generation methods fail unless a more specific flag is set.
+     */
     public bool $shouldFail = false;
+
+    public bool $shouldFailGlobal = false;
+
+    public bool $shouldFailDayTask = false;
+
+    public bool $shouldFailDayFallback = false;
+
+    public bool $shouldFailDayCommits = false;
+
+    /**
+     * Call order log: each entry is one of 'global', 'day-task', 'day-fallback', 'day-commits'.
+     *
+     * @var list<'global'|'day-task'|'day-fallback'|'day-commits'>
+     */
+    public array $callOrder = [];
+
+    /**
+     * Violations returned by validate(). An empty array means the config is valid.
+     *
+     * @var list<string>
+     */
+    public array $violations = [];
 
     public string $narrativeText = 'Mock narrative text for testing.';
 
@@ -30,11 +56,36 @@ final class MockLlmProvider implements LlmProviderInterface
 
     public string $dayCommitsText = 'Mock day commits narrative for testing.';
 
+    /**
+     * Counts how many times generateNarrative() has been called per task title.
+     * Used to distinguish global-task calls (first call per title, no previousNarratives)
+     * from day-task calls (subsequent calls OR calls with previousNarratives).
+     *
+     * @var array<string, int>
+     */
+    private array $seenTaskTitles = [];
+
     public function generateNarrative(TaskNarrativeRequest $request): TaskNarrativeResponse
     {
         $this->narrativeRequests[] = $request;
 
-        if ($this->shouldFail) {
+        // Distinguish global vs day-task by inspecting previousNarratives and seen titles.
+        // Global-task: first call for this title AND no previousNarratives passed.
+        // Day-task: second+ call for this title OR previousNarratives is not empty.
+        $isFirstCallForTitle = ! isset($this->seenTaskTitles[$request->taskTitle]);
+        $this->seenTaskTitles[$request->taskTitle] = ($this->seenTaskTitles[$request->taskTitle] ?? 0) + 1;
+
+        $isGlobal = $isFirstCallForTitle && $request->previousNarratives === [];
+
+        if ($isGlobal) {
+            $this->callOrder[] = 'global';
+            $shouldFail = $this->shouldFail || $this->shouldFailGlobal;
+        } else {
+            $this->callOrder[] = 'day-task';
+            $shouldFail = $this->shouldFail || $this->shouldFailDayTask;
+        }
+
+        if ($shouldFail) {
             throw new \RuntimeException('LLM provider error');
         }
 
@@ -48,8 +99,11 @@ final class MockLlmProvider implements LlmProviderInterface
     public function generateDayFallback(DayFallbackRequest $request): DayFallbackResponse
     {
         $this->fallbackRequests[] = $request;
+        $this->callOrder[] = 'day-fallback';
 
-        if ($this->shouldFail) {
+        $shouldFail = $this->shouldFail || $this->shouldFailDayFallback;
+
+        if ($shouldFail) {
             throw new \RuntimeException('LLM provider error');
         }
 
@@ -63,8 +117,11 @@ final class MockLlmProvider implements LlmProviderInterface
     public function generateDayFromCommits(DayCommitsNarrativeRequest $request): DayFallbackResponse
     {
         $this->dayCommitsRequests[] = $request;
+        $this->callOrder[] = 'day-commits';
 
-        if ($this->shouldFail) {
+        $shouldFail = $this->shouldFail || $this->shouldFailDayCommits;
+
+        if ($shouldFail) {
             throw new \RuntimeException('LLM provider error');
         }
 
@@ -83,5 +140,15 @@ final class MockLlmProvider implements LlmProviderInterface
     public function getProviderName(): string
     {
         return 'mock';
+    }
+
+    /**
+     * Returns validation violations for the provider configuration.
+     *
+     * @return list<string>
+     */
+    public function validate(): array
+    {
+        return $this->violations;
     }
 }

--- a/backend/tests/Unit/Domain/Narrative/Actions/GenerateNarrativesForReportTest.php
+++ b/backend/tests/Unit/Domain/Narrative/Actions/GenerateNarrativesForReportTest.php
@@ -190,9 +190,10 @@ final class GenerateNarrativesForReportTest extends TestCase
 
         ($this->action)($report);
 
-        $this->assertGreaterThanOrEqual(2, count($this->mockLlm->narrativeRequests));
-        $this->assertSame([], $this->mockLlm->narrativeRequests[0]->previousNarratives);
-        $this->assertSame([$this->mockLlm->narrativeText], $this->mockLlm->narrativeRequests[1]->previousNarratives);
+        $dayTaskRequests = $this->dayTaskRequests();
+        $this->assertGreaterThanOrEqual(2, count($dayTaskRequests));
+        $this->assertSame([], $dayTaskRequests[0]->previousNarratives);
+        $this->assertSame([$this->mockLlm->narrativeText], $dayTaskRequests[1]->previousNarratives);
     }
 
     public function test_day_task_third_day_receives_two_previous_narratives(): void
@@ -215,7 +216,9 @@ final class GenerateNarrativesForReportTest extends TestCase
 
         ($this->action)($report);
 
-        $this->assertCount(2, $this->mockLlm->narrativeRequests[2]->previousNarratives);
+        $dayTaskRequests = $this->dayTaskRequests();
+        $this->assertCount(3, $dayTaskRequests);
+        $this->assertCount(2, $dayTaskRequests[2]->previousNarratives);
     }
 
     public function test_different_tasks_do_not_share_previous_narratives(): void
@@ -275,11 +278,156 @@ final class GenerateNarrativesForReportTest extends TestCase
         $this->assertSame([], $this->mockLlm->narrativeRequests[1]->previousNarratives);
     }
 
+    /**
+     * When a day-task has no commits of its own, it must fall back to the global narrative.
+     * After the order fix (global → day-task → day-level), global has already been generated
+     * when fallback runs, so day-task gets the LLM-generated global text.
+     * With the current wrong order (day-task → day-level → global), fallback runs before
+     * global, copying whatever value the reportTask had before generation (null or DB preset).
+     *
+     * Fixture: reportTask is created with narrative=null; no commits on this specific day
+     * so the code triggers fallbackToGlobalNarrative() immediately.
+     *
+     * TDD red test — fails until the execution order is fixed to global → day-task.
+     */
+    public function test_global_task_narrative_is_generated_before_day_task_narratives(): void
+    {
+        $report = Report::factory()->draft()->create();
+        $task = Task::factory()->create();
+        $branch = Branch::factory()->create();
+        MatchResult::factory()->auto()->create(['branch_id' => $branch->id, 'task_id' => $task->id]);
+
+        // Start with null narrative so we can tell whether global ran before fallback was invoked
+        $reportTask = ReportTask::factory()->create([
+            'report_id' => $report->id,
+            'task_id'   => $task->id,
+            'narrative' => null,
+        ]);
+
+        // Day has no commits at all — fallbackToGlobalNarrative() is triggered immediately
+        $reportDay = ReportDay::factory()->fromCommits()->create(['report_id' => $report->id, 'date' => '2024-03-11']);
+        $reportDayTask = ReportDayTask::factory()->create([
+            'report_day_id'  => $reportDay->id,
+            'report_task_id' => $reportTask->id,
+        ]);
+        // No Commit created — commits list is empty, fallback fires
+
+        ($this->action)($report);
+
+        $reportDayTask->refresh();
+
+        // After the order fix: global ran first → narrativeText was set → fallback copies it
+        // Before the fix: fallback ran first while reportTask.narrative was still null
+        $this->assertSame(
+            $this->mockLlm->narrativeText,
+            $reportDayTask->narrative,
+            'Day-task fallback must contain the global LLM narrative — proving global ran before day-task'
+        );
+    }
+
+    /**
+     * When a day-task has no commits, the fallback must copy the global narrative
+     * that was generated earlier in the same invocation.
+     *
+     * Symmetrical to the order test above; kept as a focused scenario.
+     * TDD red test — fails until the execution order is fixed.
+     */
+    public function test_day_task_fallback_uses_already_generated_global_narrative(): void
+    {
+        $report = Report::factory()->draft()->create();
+        $task = Task::factory()->create();
+        $branch = Branch::factory()->create();
+        MatchResult::factory()->auto()->create(['branch_id' => $branch->id, 'task_id' => $task->id]);
+
+        $reportTask = ReportTask::factory()->create([
+            'report_id' => $report->id,
+            'task_id'   => $task->id,
+            'narrative' => null,
+        ]);
+
+        $reportDay = ReportDay::factory()->fromCommits()->create(['report_id' => $report->id, 'date' => '2024-03-11']);
+        $reportDayTask = ReportDayTask::factory()->create([
+            'report_day_id'  => $reportDay->id,
+            'report_task_id' => $reportTask->id,
+        ]);
+        // No commits → fallbackToGlobalNarrative() is triggered
+
+        ($this->action)($report);
+
+        $reportDayTask->refresh();
+
+        $this->assertSame(
+            $this->mockLlm->narrativeText,
+            $reportDayTask->narrative,
+            'When day-task falls back, it must receive the global narrative that was already generated'
+        );
+    }
+
+    /**
+     * When global LLM generation fails (placeholder is set) and the day-task also has no commits,
+     * the fallback must copy the placeholder — not null or any stale pre-DB value.
+     *
+     * With the current wrong order (day-task first), the fallback copies the pre-seeded factory
+     * value (random paragraph), not the placeholder. Only after the order fix will the placeholder
+     * be available when fallback runs.
+     *
+     * TDD red test — fails until the execution order is fixed.
+     */
+    public function test_day_task_fallback_uses_placeholder_when_global_also_failed(): void
+    {
+        $report = Report::factory()->draft()->create();
+        $task = Task::factory()->create();
+        $branch = Branch::factory()->create();
+        MatchResult::factory()->auto()->create(['branch_id' => $branch->id, 'task_id' => $task->id]);
+
+        $reportTask = ReportTask::factory()->create([
+            'report_id' => $report->id,
+            'task_id'   => $task->id,
+            'narrative' => null,
+        ]);
+
+        $reportDay = ReportDay::factory()->fromCommits()->create(['report_id' => $report->id, 'date' => '2024-03-11']);
+        $reportDayTask = ReportDayTask::factory()->create([
+            'report_day_id'  => $reportDay->id,
+            'report_task_id' => $reportTask->id,
+        ]);
+        // No commits → fallbackToGlobalNarrative() is triggered
+
+        // All LLM calls fail — global generation results in placeholder
+        $this->mockLlm->shouldFail = true;
+
+        ($this->action)($report);
+
+        $reportDayTask->refresh();
+
+        $this->assertSame(
+            '[Не удалось сгенерировать описание. Отредактируйте вручную.]',
+            $reportDayTask->narrative,
+            'When global fails (placeholder) and day-task falls back, it must receive the placeholder — not null'
+        );
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockLlm = new MockLlmProvider();
         $this->action = new GenerateNarrativesForReport($this->mockLlm, new NarrativeSupport());
+    }
+
+    /**
+     * Returns only the day-task generateNarrative() calls in call order.
+     * Filters by matching each narrativeRequests index against callOrder,
+     * so results are resilient to changes in global/day-task execution order.
+     *
+     * @return list<\App\Domain\Narrative\DTOs\TaskNarrativeRequest>
+     */
+    private function dayTaskRequests(): array
+    {
+        return array_values(array_filter(
+            $this->mockLlm->narrativeRequests,
+            fn (mixed $_, int $i): bool => ($this->mockLlm->callOrder[$i] ?? null) === 'day-task',
+            ARRAY_FILTER_USE_BOTH,
+        ));
     }
 }

--- a/backend/tests/Unit/Domain/Narrative/Actions/GenerateNarrativesForReportTest.php
+++ b/backend/tests/Unit/Domain/Narrative/Actions/GenerateNarrativesForReportTest.php
@@ -278,18 +278,7 @@ final class GenerateNarrativesForReportTest extends TestCase
         $this->assertSame([], $this->mockLlm->narrativeRequests[1]->previousNarratives);
     }
 
-    /**
-     * When a day-task has no commits of its own, it must fall back to the global narrative.
-     * After the order fix (global → day-task → day-level), global has already been generated
-     * when fallback runs, so day-task gets the LLM-generated global text.
-     * With the current wrong order (day-task → day-level → global), fallback runs before
-     * global, copying whatever value the reportTask had before generation (null or DB preset).
-     *
-     * Fixture: reportTask is created with narrative=null; no commits on this specific day
-     * so the code triggers fallbackToGlobalNarrative() immediately.
-     *
-     * TDD red test — fails until the execution order is fixed to global → day-task.
-     */
+    /** Day-task with no commits falls back to global narrative generated in the same invocation. */
     public function test_global_task_narrative_is_generated_before_day_task_narratives(): void
     {
         $report = Report::factory()->draft()->create();
@@ -297,27 +286,22 @@ final class GenerateNarrativesForReportTest extends TestCase
         $branch = Branch::factory()->create();
         MatchResult::factory()->auto()->create(['branch_id' => $branch->id, 'task_id' => $task->id]);
 
-        // Start with null narrative so we can tell whether global ran before fallback was invoked
         $reportTask = ReportTask::factory()->create([
             'report_id' => $report->id,
             'task_id'   => $task->id,
             'narrative' => null,
         ]);
 
-        // Day has no commits at all — fallbackToGlobalNarrative() is triggered immediately
         $reportDay = ReportDay::factory()->fromCommits()->create(['report_id' => $report->id, 'date' => '2024-03-11']);
         $reportDayTask = ReportDayTask::factory()->create([
             'report_day_id'  => $reportDay->id,
             'report_task_id' => $reportTask->id,
         ]);
-        // No Commit created — commits list is empty, fallback fires
 
         ($this->action)($report);
 
         $reportDayTask->refresh();
 
-        // After the order fix: global ran first → narrativeText was set → fallback copies it
-        // Before the fix: fallback ran first while reportTask.narrative was still null
         $this->assertSame(
             $this->mockLlm->narrativeText,
             $reportDayTask->narrative,
@@ -325,13 +309,6 @@ final class GenerateNarrativesForReportTest extends TestCase
         );
     }
 
-    /**
-     * When a day-task has no commits, the fallback must copy the global narrative
-     * that was generated earlier in the same invocation.
-     *
-     * Symmetrical to the order test above; kept as a focused scenario.
-     * TDD red test — fails until the execution order is fixed.
-     */
     public function test_day_task_fallback_uses_already_generated_global_narrative(): void
     {
         $report = Report::factory()->draft()->create();
@@ -350,7 +327,6 @@ final class GenerateNarrativesForReportTest extends TestCase
             'report_day_id'  => $reportDay->id,
             'report_task_id' => $reportTask->id,
         ]);
-        // No commits → fallbackToGlobalNarrative() is triggered
 
         ($this->action)($report);
 
@@ -363,16 +339,6 @@ final class GenerateNarrativesForReportTest extends TestCase
         );
     }
 
-    /**
-     * When global LLM generation fails (placeholder is set) and the day-task also has no commits,
-     * the fallback must copy the placeholder — not null or any stale pre-DB value.
-     *
-     * With the current wrong order (day-task first), the fallback copies the pre-seeded factory
-     * value (random paragraph), not the placeholder. Only after the order fix will the placeholder
-     * be available when fallback runs.
-     *
-     * TDD red test — fails until the execution order is fixed.
-     */
     public function test_day_task_fallback_uses_placeholder_when_global_also_failed(): void
     {
         $report = Report::factory()->draft()->create();
@@ -391,9 +357,7 @@ final class GenerateNarrativesForReportTest extends TestCase
             'report_day_id'  => $reportDay->id,
             'report_task_id' => $reportTask->id,
         ]);
-        // No commits → fallbackToGlobalNarrative() is triggered
 
-        // All LLM calls fail — global generation results in placeholder
         $this->mockLlm->shouldFail = true;
 
         ($this->action)($report);
@@ -415,13 +379,7 @@ final class GenerateNarrativesForReportTest extends TestCase
         $this->action = new GenerateNarrativesForReport($this->mockLlm, new NarrativeSupport());
     }
 
-    /**
-     * Returns only the day-task generateNarrative() calls in call order.
-     * Filters by matching each narrativeRequests index against callOrder,
-     * so results are resilient to changes in global/day-task execution order.
-     *
-     * @return list<\App\Domain\Narrative\DTOs\TaskNarrativeRequest>
-     */
+    /** @return list<\App\Domain\Narrative\DTOs\TaskNarrativeRequest> */
     private function dayTaskRequests(): array
     {
         return array_values(array_filter(

--- a/backend/tests/Unit/Domain/Narrative/Services/LlmConfigValidatorTest.php
+++ b/backend/tests/Unit/Domain/Narrative/Services/LlmConfigValidatorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Narrative\Services;
+
+use App\Domain\Narrative\Exceptions\InvalidLlmConfigException;
+use App\Domain\Narrative\Services\LlmConfigValidator;
+use App\Domain\Narrative\Services\LlmProviderInterface;
+use Tests\Mocks\MockLlmProvider;
+use Tests\TestCase;
+
+final class LlmConfigValidatorTest extends TestCase
+{
+    public function test_validate_aggregates_violations_from_active_provider(): void
+    {
+        $mock = new MockLlmProvider();
+        $mock->violations = ['LLM_API_KEY is required', 'LLM_MAX_TOKENS must be >= 1'];
+
+        $validator = new LlmConfigValidator($mock);
+
+        $exception = null;
+
+        try {
+            $validator->validate();
+        } catch (InvalidLlmConfigException $e) {
+            $exception = $e;
+        }
+
+        $this->assertNotNull($exception, 'Expected InvalidLlmConfigException to be thrown');
+        $this->assertContains('LLM_API_KEY is required', $exception->violations);
+        $this->assertContains('LLM_MAX_TOKENS must be >= 1', $exception->violations);
+    }
+
+    public function test_validate_passes_when_provider_returns_no_violations(): void
+    {
+        $mock = new MockLlmProvider();
+        $mock->violations = [];
+
+        $validator = new LlmConfigValidator($mock);
+
+        // Must not throw — if it does, the test will fail automatically
+        $validator->validate();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_validate_picks_provider_from_setting_then_falls_back_to_config(): void
+    {
+        $mock = new MockLlmProvider();
+        $mock->violations = ['LLM_API_KEY is required'];
+
+        $this->app->bind(LlmProviderInterface::class, fn (): MockLlmProvider => $mock);
+
+        // Resolve from container to simulate how the controller would inject it
+        /** @var LlmProviderInterface $resolvedProvider */
+        $resolvedProvider = $this->app->make(LlmProviderInterface::class);
+        $validator = new LlmConfigValidator($resolvedProvider);
+
+        $this->expectException(InvalidLlmConfigException::class);
+
+        $validator->validate();
+    }
+}

--- a/backend/tests/Unit/Domain/Narrative/Services/LlmConfigValidatorTest.php
+++ b/backend/tests/Unit/Domain/Narrative/Services/LlmConfigValidatorTest.php
@@ -39,7 +39,6 @@ final class LlmConfigValidatorTest extends TestCase
 
         $validator = new LlmConfigValidator($mock);
 
-        // Must not throw — if it does, the test will fail automatically
         $validator->validate();
 
         $this->assertTrue(true);
@@ -52,7 +51,6 @@ final class LlmConfigValidatorTest extends TestCase
 
         $this->app->bind(LlmProviderInterface::class, fn (): MockLlmProvider => $mock);
 
-        // Resolve from container to simulate how the controller would inject it
         /** @var LlmProviderInterface $resolvedProvider */
         $resolvedProvider = $this->app->make(LlmProviderInterface::class);
         $validator = new LlmConfigValidator($resolvedProvider);

--- a/backend/tests/Unit/Infrastructure/LLM/ClaudeProviderTest.php
+++ b/backend/tests/Unit/Infrastructure/LLM/ClaudeProviderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\LLM;
+
+use App\Domain\Narrative\DTOs\TaskNarrativeRequest;
+use App\Infrastructure\LLM\ClaudeProvider;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+final class ClaudeProviderTest extends TestCase
+{
+    private const string FAKE_API_KEY = 'sk-ant-test-key-1234567890abcdef';
+
+    private const string FAKE_MODEL = 'claude-sonnet-4';
+
+    private const string CLAUDE_API_PATTERN = 'https://api.anthropic.com/*';
+
+    public function test_validate_returns_violation_when_max_tokens_is_zero(): void
+    {
+        $provider = new ClaudeProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 0, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('LLM_MAX_TOKENS must be >= 1', implode(', ', $violations));
+    }
+
+    public function test_validate_returns_violation_when_max_tokens_is_negative(): void
+    {
+        $provider = new ClaudeProvider(self::FAKE_API_KEY, self::FAKE_MODEL, -1, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('LLM_MAX_TOKENS must be >= 1', implode(', ', $violations));
+    }
+
+    public function test_validate_returns_violation_when_api_key_is_empty(): void
+    {
+        $provider = new ClaudeProvider('', self::FAKE_MODEL, 1024, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('LLM_API_KEY is required', implode(', ', $violations));
+    }
+
+    public function test_validate_returns_empty_when_config_is_valid(): void
+    {
+        $provider = new ClaudeProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 1024, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertSame([], $violations);
+    }
+
+    public function test_generate_narrative_throws_when_max_tokens_below_one(): void
+    {
+        Http::fake();
+
+        $provider = new ClaudeProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 0, 'system prompt');
+        $request = new TaskNarrativeRequest(
+            taskTitle: 'Test task',
+            projectName: 'Test project',
+            commits: ['feat: add feature'],
+        );
+
+        $threw = false;
+
+        try {
+            $provider->generateNarrative($request);
+        } catch (\InvalidArgumentException) {
+            $threw = true;
+        } catch (\Throwable) {
+            // Swallow other exceptions — guard not yet implemented
+        }
+
+        Http::assertNothingSent();
+        $this->assertTrue($threw, 'Expected InvalidArgumentException before any HTTP request is made');
+    }
+
+    public function test_generate_narrative_throws_when_api_returns_empty_text(): void
+    {
+        Http::fake([
+            self::CLAUDE_API_PATTERN => Http::response([
+                'content' => [['type' => 'text', 'text' => '']],
+                'usage'   => ['input_tokens' => 10, 'output_tokens' => 0],
+            ], 200),
+        ]);
+
+        $provider = new ClaudeProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 1024, 'system prompt');
+        $request = new TaskNarrativeRequest(
+            taskTitle: 'Test task',
+            projectName: 'Test project',
+            commits: ['feat: add feature'],
+        );
+
+        $this->expectException(\RuntimeException::class);
+
+        $provider->generateNarrative($request);
+    }
+
+    public function test_generate_narrative_succeeds_on_valid_response(): void
+    {
+        $expectedNarrative = 'Generated narrative text for the task.';
+
+        Http::fake([
+            self::CLAUDE_API_PATTERN => Http::response([
+                'content' => [['type' => 'text', 'text' => $expectedNarrative]],
+                'usage'   => ['input_tokens' => 100, 'output_tokens' => 50],
+            ], 200),
+        ]);
+
+        $provider = new ClaudeProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 1024, 'system prompt');
+        $request = new TaskNarrativeRequest(
+            taskTitle: 'Test task',
+            projectName: 'Test project',
+            commits: ['feat: add feature'],
+        );
+
+        $response = $provider->generateNarrative($request);
+
+        $this->assertSame($expectedNarrative, $response->narrative);
+
+        Http::assertSent(function (\Illuminate\Http\Client\Request $sentRequest): bool {
+            $body = json_decode($sentRequest->body(), true);
+
+            return is_array($body) && isset($body['max_tokens']) && $body['max_tokens'] === 1024;
+        });
+    }
+}

--- a/backend/tests/Unit/Infrastructure/LLM/ClaudeProviderTest.php
+++ b/backend/tests/Unit/Infrastructure/LLM/ClaudeProviderTest.php
@@ -74,7 +74,6 @@ final class ClaudeProviderTest extends TestCase
         } catch (\InvalidArgumentException) {
             $threw = true;
         } catch (\Throwable) {
-            // Swallow other exceptions — guard not yet implemented
         }
 
         Http::assertNothingSent();

--- a/backend/tests/Unit/Infrastructure/LLM/OpenAiProviderTest.php
+++ b/backend/tests/Unit/Infrastructure/LLM/OpenAiProviderTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\LLM;
+
+use App\Domain\Narrative\DTOs\TaskNarrativeRequest;
+use App\Infrastructure\LLM\OpenAiProvider;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+final class OpenAiProviderTest extends TestCase
+{
+    private const string FAKE_API_KEY = 'sk-test-openai-key-1234567890abcdef';
+
+    private const string FAKE_MODEL = 'gpt-4o';
+
+    private const string OPENAI_API_PATTERN = 'https://api.openai.com/*';
+
+    public function test_validate_returns_violation_when_max_tokens_is_zero(): void
+    {
+        $provider = new OpenAiProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 0, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('LLM_MAX_TOKENS must be >= 1', implode(', ', $violations));
+    }
+
+    public function test_validate_returns_violation_when_max_tokens_is_negative(): void
+    {
+        $provider = new OpenAiProvider(self::FAKE_API_KEY, self::FAKE_MODEL, -5, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('LLM_MAX_TOKENS must be >= 1', implode(', ', $violations));
+    }
+
+    public function test_validate_returns_violation_when_api_key_is_empty(): void
+    {
+        $provider = new OpenAiProvider('', self::FAKE_MODEL, 1024, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertNotEmpty($violations);
+        $this->assertStringContainsString('LLM_API_KEY is required', implode(', ', $violations));
+    }
+
+    public function test_validate_returns_empty_when_config_is_valid(): void
+    {
+        $provider = new OpenAiProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 1024, 'system prompt');
+
+        $violations = $provider->validate();
+
+        $this->assertSame([], $violations);
+    }
+
+    public function test_generate_narrative_throws_when_max_tokens_below_one(): void
+    {
+        Http::fake();
+
+        $provider = new OpenAiProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 0, 'system prompt');
+        $request = new TaskNarrativeRequest(
+            taskTitle: 'Test task',
+            projectName: 'Test project',
+            commits: ['feat: add feature'],
+        );
+
+        $threw = false;
+
+        try {
+            $provider->generateNarrative($request);
+        } catch (\InvalidArgumentException) {
+            $threw = true;
+        } catch (\Throwable) {
+            // Swallow other exceptions — guard not yet implemented
+        }
+
+        Http::assertNothingSent();
+        $this->assertTrue($threw, 'Expected InvalidArgumentException before any HTTP request is made');
+    }
+
+    public function test_generate_narrative_throws_when_api_returns_empty_content(): void
+    {
+        Http::fake([
+            self::OPENAI_API_PATTERN => Http::response([
+                'choices' => [
+                    ['message' => ['content' => '']],
+                ],
+                'usage' => ['total_tokens' => 10],
+            ], 200),
+        ]);
+
+        $provider = new OpenAiProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 1024, 'system prompt');
+        $request = new TaskNarrativeRequest(
+            taskTitle: 'Test task',
+            projectName: 'Test project',
+            commits: ['feat: add feature'],
+        );
+
+        $this->expectException(\RuntimeException::class);
+
+        $provider->generateNarrative($request);
+    }
+
+    public function test_generate_narrative_succeeds_on_valid_response(): void
+    {
+        $expectedNarrative = 'Generated narrative text from OpenAI.';
+
+        Http::fake([
+            self::OPENAI_API_PATTERN => Http::response([
+                'choices' => [
+                    ['message' => ['content' => $expectedNarrative]],
+                ],
+                'usage' => ['total_tokens' => 150],
+            ], 200),
+        ]);
+
+        $provider = new OpenAiProvider(self::FAKE_API_KEY, self::FAKE_MODEL, 1024, 'system prompt');
+        $request = new TaskNarrativeRequest(
+            taskTitle: 'Test task',
+            projectName: 'Test project',
+            commits: ['feat: add feature'],
+        );
+
+        $response = $provider->generateNarrative($request);
+
+        $this->assertSame($expectedNarrative, $response->narrative);
+
+        Http::assertSent(function (\Illuminate\Http\Client\Request $sentRequest): bool {
+            $body = json_decode($sentRequest->body(), true);
+
+            return is_array($body) && isset($body['max_tokens']) && $body['max_tokens'] === 1024;
+        });
+    }
+}

--- a/backend/tests/Unit/Infrastructure/LLM/OpenAiProviderTest.php
+++ b/backend/tests/Unit/Infrastructure/LLM/OpenAiProviderTest.php
@@ -74,7 +74,6 @@ final class OpenAiProviderTest extends TestCase
         } catch (\InvalidArgumentException) {
             $threw = true;
         } catch (\Throwable) {
-            // Swallow other exceptions — guard not yet implemented
         }
 
         Http::assertNothingSent();

--- a/frontend/src/pages/ReportPage.tsx
+++ b/frontend/src/pages/ReportPage.tsx
@@ -7,6 +7,8 @@ import {
   useExportPrompt,
 } from "../hooks/useReports";
 import type { GenerateReportParams } from "../api/reports";
+import { ApiError } from "../api/client";
+import type { LlmConfigErrorData } from "../types/api";
 import { ReportDaysTab } from "../components/report/ReportDaysTab";
 import { ReportTasksTab } from "../components/report/ReportTasksTab";
 import { ReportsList } from "../components/report/ReportsList";
@@ -65,6 +67,24 @@ function todayStr(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+function extractLlmConfigError(error: unknown): LlmConfigErrorData | null {
+  if (!(error instanceof ApiError) || error.status !== 422) {
+    return null;
+  }
+  const data = error.data;
+  if (data === null || typeof data !== "object") {
+    return null;
+  }
+  const violations = (data as { violations?: unknown }).violations;
+  if (!Array.isArray(violations)) {
+    return null;
+  }
+  if (!violations.every((v): v is string => typeof v === "string")) {
+    return null;
+  }
+  return data as LlmConfigErrorData;
+}
+
 export function ReportPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -115,7 +135,17 @@ export function ReportPage() {
           navigate(`/reports/${data.id}`);
         }
       },
-      onError: () => {
+      onError: (error) => {
+        const llmConfigError = extractLlmConfigError(error);
+        if (llmConfigError) {
+          const violations = llmConfigError.violations
+            .map((v) => `• ${v}`)
+            .join("\n");
+          setErrorMessage(
+            `Конфигурация LLM некорректна:\n${violations}\n\nОткройте Настройки и заполните необходимые поля.`,
+          );
+          return;
+        }
         setErrorMessage(
           "Не удалось сгенерировать отчёт. Проверьте наличие данных за выбранный период.",
         );
@@ -352,6 +382,7 @@ export function ReportPage() {
                 color: "#c53030",
                 marginBottom: "16px",
                 fontSize: "14px",
+                whiteSpace: "pre-line",
               }}
             >
               {errorMessage}

--- a/frontend/src/pages/__tests__/ReportPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReportPage.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ApiError } from "../../api/client";
+import { ReportPage } from "../ReportPage";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../api/reports", () => ({
+  reportsApi: {
+    generate: vi.fn(),
+    list: vi.fn().mockResolvedValue({
+      data: [],
+      meta: { current_page: 1, last_page: 1, per_page: 15, total: 0 },
+    }),
+    getPreview: vi.fn(),
+  },
+}));
+
+// We also need to mock the hooks so they call the mocked api module.
+// useGenerateReport internally calls reportsApi.generate via useMutation.
+// Because we mock the module, the hook will use our mocked version.
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderReportPage(path = "/reports"): void {
+  render(
+    <QueryClientProvider client={buildQueryClient()}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/reports" element={<ReportPage />} />
+          <Route path="/reports/:id" element={<ReportPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ReportPage — LLM config error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows llm config error inline when backend returns 422 with violations", async () => {
+    const { reportsApi } = await import("../../api/reports");
+
+    vi.mocked(reportsApi.generate).mockRejectedValue(
+      new ApiError("Request failed with status 422", 422, {
+        error: "LLM configuration is invalid",
+        violations: ["LLM_MAX_TOKENS must be >= 1"],
+        settings_url: "/settings",
+      }),
+    );
+
+    renderReportPage();
+
+    const generateButton = await screen.findByRole("button", {
+      name: /Сгенерировать/i,
+    });
+
+    await userEvent.click(generateButton);
+
+    // After the frontend agent implements 422/violations handling, this text must appear.
+    // Until then (TDD red), the component falls through to the generic error message.
+    await waitFor(() => {
+      expect(screen.getByText(/LLM_MAX_TOKENS/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error when backend returns other 4xx without violations", async () => {
+    const { reportsApi } = await import("../../api/reports");
+
+    vi.mocked(reportsApi.generate).mockRejectedValue(
+      new ApiError("Request failed with status 400", 400, {
+        error: "Bad request",
+      }),
+    );
+
+    renderReportPage();
+
+    const generateButton = await screen.findByRole("button", {
+      name: /Сгенерировать/i,
+    });
+
+    await userEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Не удалось сгенерировать отчёт/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/ReportPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReportPage.test.tsx
@@ -6,10 +6,6 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { ApiError } from "../../api/client";
 import { ReportPage } from "../ReportPage";
 
-// ---------------------------------------------------------------------------
-// Module mocks
-// ---------------------------------------------------------------------------
-
 vi.mock("../../api/reports", () => ({
   reportsApi: {
     generate: vi.fn(),
@@ -20,14 +16,6 @@ vi.mock("../../api/reports", () => ({
     getPreview: vi.fn(),
   },
 }));
-
-// We also need to mock the hooks so they call the mocked api module.
-// useGenerateReport internally calls reportsApi.generate via useMutation.
-// Because we mock the module, the hook will use our mocked version.
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 function buildQueryClient(): QueryClient {
   return new QueryClient({
@@ -50,10 +38,6 @@ function renderReportPage(path = "/reports"): void {
     </QueryClientProvider>,
   );
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe("ReportPage — LLM config error handling", () => {
   beforeEach(() => {
@@ -79,8 +63,6 @@ describe("ReportPage — LLM config error handling", () => {
 
     await userEvent.click(generateButton);
 
-    // After the frontend agent implements 422/violations handling, this text must appear.
-    // Until then (TDD red), the component falls through to the generic error message.
     await waitFor(() => {
       expect(screen.getByText(/LLM_MAX_TOKENS/i)).toBeInTheDocument();
     });

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -77,6 +77,12 @@ export interface PaginatedResponse<T> {
   };
 }
 
+export interface LlmConfigErrorData {
+  error: string;
+  violations: string[];
+  settings_url?: string;
+}
+
 export interface InboxItem {
   id: number;
   branch_name: string;


### PR DESCRIPTION
## What changes

- Add an LLM-config preflight in `ReportController::generate()`: when api_key / max_tokens / model are invalid, generation aborts with **HTTP 422** before any `Report` row is created.
- LLM providers (`ClaudeProvider`, `OpenAiProvider`) now expose `validate(): list<string>`, throw `InvalidArgumentException` when `max_tokens < 1` **before** the HTTP call, and throw `RuntimeException` when the API returns empty `content`.
- New domain exception `InvalidLlmConfigException`, rendered in `bootstrap/app.php` as `{error, violations, settings_url}` with a `Log::warning` that excludes secrets.
- Reorder narrative generation in `GenerateNarrativesForReport::__invoke()` to **global → day-task → day-level**, with a relation reload between stages so the day-task fallback inherits the freshly-written global narrative instead of `null`.
- `ReportPage` parses the 422 shape and shows the specific violations inline (with a pointer to Settings), replacing the generic "failed to generate report" message for this case.
- Full test coverage:
  - `ClaudeProviderTest`, `OpenAiProviderTest` — `validate()` violations, pre-HTTP guard, empty-response handling, happy path.
  - `LlmConfigValidatorTest` — aggregates violations into the new exception.
  - `ReportGenerationValidationTest` (feature) — endpoint returns 422 with violations, no `Report` row is created.
  - `GenerateNarrativesForReportTest` — ordering + fallback behavior under partial failure; existing index-based tests refactored to be order-resilient via `callOrder`.
  - `ReportPage.test.tsx` — inline violations + generic fallback for other 4xx.

## Why

Report #36 was generated with empty LLM descriptions because `LLM_MAX_TOKENS=` in `.env` is parsed by Laravel `env()` as `''` (the default is only used when the key is **unset**, not when it is empty). `(int) '' === 0` → `config('llm.providers.claude.max_tokens') = 0`. Anthropic responds with HTTP 200 and empty `content[0].text` when called with `max_tokens=0` — no error, no log, just empty narratives written to `ReportTask` / `ReportDayTask`.

Two failure modes compounded the user-visible symptom:
1. The previous generation order (`day-task → day-level → global-task`) meant that when day-task LLM hit any error, `fallbackToGlobalNarrative()` copied a still-`null` global narrative, so cells stayed empty even when a later global-task pass produced a placeholder.
2. The UI surfaced nothing — the user only noticed in the downloaded Word document, well after the `Report` had been persisted and exported.

This PR fails fast on misconfiguration, makes the fallback path actually useful when an LLM call fails mid-generation, and tells the user up front to fix Settings instead of producing a half-empty report.

## How to verify

Automated:
- `docker compose exec -T app php artisan test` → **422 passed**
- `docker compose exec -T node npm test -- --run` → **18 passed** (incl. 2 new `ReportPage` tests)
- `vendor/bin/phpstan analyse`, `vendor/bin/pint --test`, `npm run lint` → clean

Manual smoke:
1. Set `LLM_MAX_TOKENS=` (empty) in `.env`, restart `app`. Open `/reports`, click *Сгенерировать* → inline error lists `LLM_MAX_TOKENS must be >= 1`, no `Report` row is created.
2. Clear `Setting::llm_api_key` via the UI → same flow returns 422 with `LLM_API_KEY is required`.
3. Fix the config (`LLM_MAX_TOKENS=1024`, valid api_key) → generation completes and narratives are populated end-to-end.

## Checklist

- [x] Branch name follows Conventional Branch (`fix/llm-config-preflight`)
- [x] PR title follows Conventional Commits
- [x] `make lint` and `make test` pass locally
- [x] Documentation updated (if user-visible behavior is affected) — N/A, no docs site / changelog entries needed (release-please drives CHANGELOG from the squashed title)
- [x] One logical change in the PR (multiple tasks not mixed)