### PR TITLE
chore(github): simplify PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,24 +4,16 @@ title: "fix: "
 labels: ["bug"]
 body:
   - type: textarea
-    id: what-happened
+    id: description
     attributes:
-      label: What happened
-      description: Describe the observed behavior.
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: What you expected
-      description: The behavior you expected to see.
+      label: Description
+      description: What happened and what you expected to see instead.
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
       label: Steps to reproduce
-      description: A step-by-step recipe.
       placeholder: |
         1. Open the /reports page
         2. Click "Generate"
@@ -29,21 +21,9 @@ body:
     validations:
       required: true
   - type: textarea
-    id: environment
-    attributes:
-      label: Environment
-      placeholder: |
-        OS:           Windows 11
-        PHP:          8.2.12
-        Docker:       24.0.6
-        Branch:       master @ commit abc123
-    validations:
-      required: false
-  - type: textarea
     id: logs
     attributes:
       label: Logs / screenshots
-      description: If available.
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,31 +7,22 @@ body:
     id: problem
     attributes:
       label: Problem this solves
-      description: Describe the problem the feature would solve. Without a problem statement the feature isn't justified.
+      description: Without a problem statement the feature isn't justified.
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
       label: Proposed solution
-      description: How you see the implementation. High-level is fine.
+      description: High-level is fine.
     validations:
       required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives
-      description: Other options considered and why they were rejected.
-    validations:
-      required: false
   - type: textarea
     id: acceptance
     attributes:
       label: Acceptance criteria
-      description: How we'll know the feature is done.
       placeholder: |
         - [ ] Endpoint /api/foo returns 200 for a valid request
         - [ ] Covered by a unit test
-        - [ ] Documented in README/AGENTS
     validations:
       required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,30 +2,17 @@
 The PR title must follow Conventional Commits, for example:
   feat(bitrix): sanitize PII in comment payload
   fix(report): correct LLM token counter for Russian text
-  chore(deps): bump phpoffice/phpword to 1.4.1
 
-It becomes the message of the single commit produced by squash-merge,
-which directly drives CHANGELOG.md and the SemVer bump.
+It becomes the squash-merge commit message and drives CHANGELOG.md / SemVer.
 -->
 
-## What changes
+## Description
 
-<!-- Briefly: what this PR does. One logical change. -->
-
-## Why
-
-<!-- The problem this solves. Link to the issue. -->
+<!-- What this PR does and why. One logical change. -->
 
 Closes #
 
-## How to verify
-
-<!-- Manual verification steps or a link to tests. -->
-
 ## Checklist
 
-- [ ] Branch name follows Conventional Branch (`<type>/<slug>` or `<type>/<issue#>-<slug>`)
 - [ ] PR title follows Conventional Commits
 - [ ] `make lint` and `make test` pass locally
-- [ ] Documentation updated (if user-visible behavior is affected)
-- [ ] One logical change in the PR (multiple tasks not mixed)


### PR DESCRIPTION
## Description

Trim GitHub templates to match the size of a single-maintainer project and
remove fields that duplicate what CI already verifies.

- **PR template**: 5 sections → 2. Merge `What changes` + `Why` into a single
  `Description`, drop `How to verify` (CI runs lint/tests), shrink the checklist
  from 5 items to 2 (Conventional Commits title + local lint/test pass). The
  Conventional Commits hint comment is kept — release-please depends on it.
- **bug_report.yml**: 5 fields → 3. Merge `What happened` + `What you expected`
  into a single `Description`, drop the `Environment` block.
- **feature_request.yml**: 4 fields → 3. Drop `Alternatives` (almost always
  left empty in practice).

Aligned with the minimalist style used by composer/composer, phpunit/phpunit
and guzzlehttp/guzzle.

Closes #133 

## Checklist

- [x] PR title follows Conventional Commits
- [x] `make lint` and `make test` pass locally
