### PR TITLE
fix(ui): make day card action buttons readable in dark theme

### DIFF
--- a/frontend/src/components/report/ReportDaysTab.tsx
+++ b/frontend/src/components/report/ReportDaysTab.tsx
@@ -213,6 +213,7 @@ export function ReportDaysTab({ reportId, days }: Props) {
                   style={{
                     padding: "4px 12px",
                     background: "#eee",
+                    color: "#333",
                     border: "none",
                     borderRadius: "4px",
                     cursor: "pointer",
@@ -228,6 +229,7 @@ export function ReportDaysTab({ reportId, days }: Props) {
                   style={{
                     padding: "4px 12px",
                     background: "#eee",
+                    color: "#333",
                     border: "none",
                     borderRadius: "4px",
                     cursor: regenerateDay.isPending ? "not-allowed" : "pointer",
@@ -243,6 +245,7 @@ export function ReportDaysTab({ reportId, days }: Props) {
                   style={{
                     padding: "4px 12px",
                     background: "#eee",
+                    color: "#333",
                     border: "none",
                     borderRadius: "4px",
                     cursor: undoDay.isPending ? "not-allowed" : "pointer",


### PR DESCRIPTION
The Edit / Regenerate / Undo buttons under each day card on the report detail page set an inline background of #eee but did not set color. User-agent styles give <button> a system buttontext color that does not inherit from the parent card, so on a dark system color scheme the text rendered light-on-light and the labels became invisible.

Add color: "#333" to the three buttons, matching the pattern already used by the Cancel button in edit mode of the same component.

Closes #137 
