### PR TITLE
ci: add hadolint Dockerfile linter

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache --virtual .build-deps autoconf gcc g++ make \
     && docker-php-ext-enable redis \
     && apk del .build-deps
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 COPY nginx.conf /etc/nginx/http.d/default.conf
 COPY php.ini /usr/local/etc/php/conf.d/custom.ini

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,12 @@
 # Default: auto-detect text/binary, normalize line endings on commit
 * text=auto
 
-# Always LF — executed by Linux (shell, Dockerfiles, entrypoints)
+# Always LF — executed by Linux (shell, Dockerfiles, entrypoints, Makefile)
 *.sh           text eol=lf
 *.bash         text eol=lf
 Dockerfile     text eol=lf
 *.dockerfile   text eol=lf
+Makefile       text eol=lf
 
 # Config files read by Linux tools in containers
 *.conf         text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,3 +184,12 @@ jobs:
 
       - name: Run Vitest
         run: npm run test:ci
+
+  # ─── Docker: hadolint ─────────────────────────────────────────
+  lint-dockerfile:
+    name: Dockerfile lint (hadolint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: hadolint (same `make lint-docker` as local)
+        run: make lint-docker

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,15 @@
+# hadolint configuration — https://github.com/hadolint/hadolint#configure
+failure-threshold: warning
+
+# Lock FROM images to trusted registries (activates DL3026).
+trustedRegistries:
+  - docker.io
+  - ghcr.io
+
+ignored:
+  # DL3018 "Pin versions in apk add".
+  # Alpine package mirrors keep only the current version of each package for a
+  # given release, so a pinned `pkg=1.2.3-r0` disappears once Alpine ships -r1
+  # and the build breaks. Reproducibility is anchored on the pinned Alpine base
+  # image tags (php:8.4-fpm-alpine, node:20-alpine) instead.
+  - DL3018

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ make down        # stop containers
 make build       # rebuild images
 make migrate     # apply migrations (php artisan migrate)
 make test        # PHPUnit — all tests (vendor/bin/phpunit)
-make lint        # all checks: Pint, PHPStan, ESLint, Prettier
+make lint        # all checks: Pint, PHPStan, ESLint, Prettier, hadolint
 make fix         # auto-fix: Pint + Prettier
 make shell       # sh shell inside the app container
 make logs        # docker compose logs -f

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,11 @@ The commit message is checked automatically in the commit-msg hook (lefthook).
 - TypeScript strict mode, functional components.
 - ESLint + Prettier for linting and formatting.
 
+### Docker
+
+- Dockerfiles (`.docker/*/Dockerfile`) are linted with [hadolint](https://github.com/hadolint/hadolint).
+- `DL3018` (pin apk versions) is intentionally disabled — see `.hadolint.yaml` for the rationale.
+
 ### Pre-commit checks
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: up down build restart logs shell migrate lint fix test
+.PHONY: up down build restart logs shell migrate lint lint-docker fix test
+
+HADOLINT_IMAGE := ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e
 
 up:
 	docker compose up -d
@@ -20,11 +22,18 @@ shell:
 migrate:
 	docker compose exec app php artisan migrate
 
-lint:
+lint: lint-docker
 	docker compose exec app sh -c "cd /var/www && vendor/bin/pint --test"
 	docker compose exec app sh -c "cd /var/www && vendor/bin/phpstan analyse --no-progress"
 	docker compose exec node sh -c "cd /app && npx eslint src/"
 	docker compose exec node sh -c "cd /app && npx prettier --check src/"
+
+# hadolint runs via `docker run` (no compose containers needed).
+# MSYS_NO_PATHCONV=1 stops Git Bash on Windows from mangling the container paths;
+# it is a harmless no-op on Linux/CI.
+lint-docker:
+	MSYS_NO_PATHCONV=1 docker run --rm -v "$$(pwd):/repo:ro" -w /repo $(HADOLINT_IMAGE) \
+		hadolint .docker/app/Dockerfile .docker/worker/Dockerfile .docker/node/Dockerfile
 
 fix:
 	docker compose exec app sh -c "cd /var/www && vendor/bin/pint"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ make down        # Stop containers
 make build       # Rebuild images
 make migrate     # Apply migrations
 make test        # Run tests (PHPUnit)
-make lint        # Lint the code (Pint, PHPStan, ESLint, Prettier)
+make lint        # Lint the code (Pint, PHPStan, ESLint, Prettier, hadolint)
 make fix         # Auto-format
 make shell       # Shell inside the app container
 make logs        # Container logs

--- a/backend/README.md
+++ b/backend/README.md
@@ -48,7 +48,7 @@ Backend-specific commands:
 
 - `make migrate` — apply migrations
 - `make test` — PHPUnit (in-memory SQLite)
-- `make lint` — Pint + PHPStan (level 10)
+- `make lint` — Pint + PHPStan (level 10) + hadolint
 - `make fix` — Pint auto-fixes
 - Run a specific test: `docker exec moronocracy-backend php artisan test --filter=TestName`
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,7 +54,7 @@ Local commands (the npm scripts in `package.json`) run inside the `node` contain
 Linting and auto-fix run from the repo root for the whole repo:
 
 ```bash
-make lint   # backend + frontend (Pint, PHPStan, ESLint, Prettier)
+make lint   # backend + frontend (Pint, PHPStan, ESLint, Prettier, hadolint)
 make fix    # auto-fix (Pint + Prettier)
 ```
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -86,6 +86,14 @@ pre-commit:
       skip:
         - merge
         - rebase
+    dockerfile-lint:
+      # Pinned digest must match the Makefile's HADOLINT_IMAGE.
+      # MSYS_NO_PATHCONV=1 — Windows/Git Bash path-mangling guard (no-op elsewhere).
+      glob: ".docker/**/Dockerfile"
+      run: MSYS_NO_PATHCONV=1 docker run --rm -v "$PWD:/repo:ro" -w /repo ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint {staged_files}
+      skip:
+        - merge
+        - rebase
 
 # pre-push can be enabled once the tests are stably green.
 # pre-push:


### PR DESCRIPTION
## What

Adds [hadolint](https://github.com/hadolint/hadolint) linting for the three Dockerfiles (`app`, `worker`, `node`) — the one artifact the repo's lint matrix did not yet cover (PHP, TS/JS, commits, branches, and tests were all covered; Docker was not).

## How

hadolint runs as a plain command via `make lint-docker`, so the local pre-commit hook, `make`, and CI use the exact same invocation — consistent with how Pint/PHPStan/ESLint/Prettier already run. No GitHub Action is involved.

- **`.hadolint.yaml`** — `failure-threshold: warning`, `trustedRegistries: [docker.io, ghcr.io]`, and an intentional `DL3018` ignore (pinning apk versions on Alpine is brittle; reproducibility stays anchored on the pinned base-image tags).
- **`Makefile`** — digest-pinned `ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352…`; `lint-docker` target wired into `lint`. `MSYS_NO_PATHCONV=1` guards Git Bash path-mangling on Windows (no-op on Linux/CI).
- **`.github/workflows/ci.yml`** — `lint-dockerfile` job calling `make lint-docker`.
- **`lefthook.yml`** — `dockerfile-lint` pre-commit hook on `.docker/**/Dockerfile`.
- **`.docker/app/Dockerfile`** — pin `composer:latest` → `composer:2`.
- **`.gitattributes`** — force `Makefile` to LF (the new recipe uses a `\` continuation).
- **Docs** — hadolint added to the lint-stack listings (README, AGENTS, CONTRIBUTING, backend/README, frontend/README).

## Verification

`hadolint .docker/app/Dockerfile .docker/worker/Dockerfile .docker/node/Dockerfile` → exit `0` (the four `DL3018` warnings are ignored by config; `trustedRegistries` satisfied). The new pre-commit hook also passed live on this branch's commit.

## Notes

- The image is **digest-pinned** for supply-chain safety (an immutable digest can't be repointed by a hijacked tag). Bumped manually on hadolint releases (~yearly) — not Dependabot-tracked, the trade-off for not using an Action.
- The `composer:2` pin is a small reproducibility win folded in while editing the file; hadolint does not flag it (`DL3007` only checks `FROM`, not `COPY --from`).

Closes #153