### PR TITLE
fix(logging): isolate test-run logs in a dedicated daily channel

### DIFF
--- a/backend/config/logging.php
+++ b/backend/config/logging.php
@@ -73,6 +73,14 @@ return [
             'replace_placeholders' => true,
         ],
 
+        'testing' => [
+            'driver'               => 'daily',
+            'path'                 => storage_path('logs/testing.log'),
+            'level'                => env('LOG_LEVEL', 'debug'),
+            'days'                 => env('LOG_TESTING_DAYS', 1),
+            'replace_placeholders' => true,
+        ],
+
         'slack' => [
             'driver'               => 'slack',
             'url'                  => env('LOG_SLACK_WEBHOOK_URL'),

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -33,6 +33,6 @@
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
-        <env name="LOG_CHANNEL" value="false"/>
+        <env name="LOG_CHANNEL" value="testing"/>
     </php>
 </phpunit>


### PR DESCRIPTION
## Description

`backend/phpunit.xml` set `LOG_CHANNEL=false`, a channel that does not exist in `config/logging.php`. During tests every `Log::*()` call failed to resolve it, fell back to Laravel's **emergency logger**, and wrote into `storage/logs/laravel.log` — adding a `laravel.EMERGENCY: Unable to create configured logger` record per call. Instead of suppressing logs, the config doubled them and polluted the runtime log with ~9 MB of expected test error-path noise.

This adds a dedicated `testing` channel (daily driver, 1-day retention) and points `LOG_CHANNEL` at it, so test-time application logs stay isolated and `laravel.log` is reserved for runtime. Tests that assert logging via `Log::fake()`/`Log::spy()` are unaffected (the facade is swapped before the handler). Retention is overridable via `LOG_TESTING_DAYS`.

Verified locally (the Docker `app` container was down, so the Pint/PHPStan pre-commit hooks could not run; the same checks were executed directly):

- `vendor/bin/pint --test` -> passed
- `vendor/bin/phpstan analyse` (level 10) -> no errors
- `vendor/bin/phpunit` -> 422 tests, 1102 assertions, OK
- After a full run, `storage/logs/laravel.log` stays empty; logs land in `storage/logs/testing-YYYY-MM-DD.log`.

Closes #157

## Checklist

- [x] PR title follows Conventional Commits
- [x] `make lint` and `make test` pass locally (ran pint / phpstan / phpunit directly; Docker `app` container was down)
